### PR TITLE
Add component builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ logs/*
 # Ignore C++ build files
 addons/glecs/cpp/.sconsign.dblite
 *.os
+addons/glecs/cpp/.cache
+addons/glecs/cpp/compile_commands.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,8 @@
             "program": "${config:godotTools.editorPath.godot4}",
       "args": [
         "--path",
-        "${workspaceFolder}"
+        "${workspaceFolder}",
+        "--headless"
       ],
             "cwd": "${workspaceFolder}"
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,8 +7,11 @@
             "type": "lldb",
             "preLaunchTask": "godot-extension: Build Debug",
             "program": "${config:godotTools.editorPath.godot4}",
-            "args": ["--path", "${workspaceFolder}"],
+      "args": [
+        "--path",
+        "${workspaceFolder}"
+      ],
             "cwd": "${workspaceFolder}"
-        },
+    }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,218 @@
 {
-	"rust-analyzer.linkedProjects": [
-		"./addons/glecs/rust/glecs/Cargo.toml",
-		"./addons/glecs/rust/flecs-rs/Cargo.toml",
-	],
-	"godot-rust.environment.godotProjectPath": "${workspaceFolder}"
+  "editor.tabSize": 4,
+  "editor.rulers": [
+    120
+  ],
+  "editor.renderWhitespace": "trailing",
+  "editor.suggestSelection": "first",
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.stickyScroll.enabled": false,
+  "editor.bracketPairColorization.enabled": false,
+  "editor.cursorSmoothCaretAnimation": "on",
+  "editor.suggest.preview": true,
+  "terminal.integrated.defaultProfile.windows": "Command Prompt",
+  "debug.onTaskErrors": "debugAnyway",
+  "explorer.compactFolders": false,
+  "explorer.confirmDragAndDrop": false,
+  "explorer.confirmDelete": false,
+  "explorer.copyRelativePathSeparator": "/",
+  "files.autoSave": "onFocusChange",
+  "files.exclude": {
+    "node_modules/**/*": true,
+    "**/.classpath": true,
+    "**/.project": true,
+    "**/.settings": true,
+    "**/.factorypath": true
+  },
+  "files.associations": {
+    ".clang*": "yaml",
+    "*.hpp.in": "cpp",
+    "*.in": "cpp"
+  },
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true,
+  "workbench.startupEditor": "none",
+  "workbench.editorAssociations": {
+    "*.md": "vscode.markdown.preview.editor",
+    "*.svg": "svgPreviewer.customEditor"
+  },
+  "workbench.colorTheme": "Default Dark+",
+  "git.enableSmartCommit": true,
+  "git.autofetch": true,
+  "git.confirmSync": false,
+  "git.openRepositoryInParentFolders": "always",
+  "prettier.tabWidth": 4,
+  "prettier.singleQuote": true,
+  "prettier.jsxSingleQuote": true,
+  "prettier.trailingComma": "all",
+  "prettier.useEditorConfig": true,
+  "prettier.bracketSpacing": false,
+  "markdown.validate.enabled": true,
+  "[markdown]": {
+    "files.trimTrailingWhitespace": false,
+    "editor.formatOnSave": false,
+    "editor.defaultFormatter": "yzhang.markdown-all-in-one",
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 120
+  },
+  "[yaml]": {
+    "editor.formatOnSave": false,
+    "editor.defaultFormatter": "redhat.vscode-yaml",
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 120
+  },
+  "[json]": {
+    "editor.formatOnSave": false,
+    "editor.defaultFormatter": "vscode.json-language-features"
+  },
+  "[jsonc]": {
+    "editor.formatOnSave": false
+  },
+  "[plaintext]": {
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 120
+  },
+  "[toml]": {
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 120
+  },
+  "better-comments.tags": [
+    {
+      "tag": "XXX",
+      "color": "#F8C471"
+    },
+    {
+      "tag": "WARN",
+      "color": "#FF6961"
+    },
+    {
+      "tag": "NOTE",
+      "color": "#3498DB"
+    },
+    {
+      "tag": "TODO",
+      "color": "#77C3EC"
+    }
+  ],
+  "vsintellicode.modify.editor.suggestSelection": "automaticallyOverrodeDefaultValue",
+  "codesnap.showWindowControls": false,
+  "codesnap.shutterAction": "copy",
+  "Workspace_Formatter.excludePattern": [
+    "**/build",
+    "**/.*",
+    "**/.vscode",
+    "**/html"
+  ],
+  "Workspace_Formatter.includePattern": [
+    "*.c",
+    "*.h",
+    "*.cc",
+    "*.hh",
+    "*.cpp",
+    "*.hpp"
+  ],
+  "svg.preview.autoOpen": true,
+  "remote.WSL.fileWatcher.polling": true,
+  "errorLens.delay": 1000,
+  "errorLens.enabledDiagnosticLevels": [
+    "error",
+    "warning"
+  ],
+  "errorLens.enabled": false,
+  "C_Cpp.clang_format_sortIncludes": true,
+  "C_Cpp.vcFormat.indent.preserveComments": true,
+  "C_Cpp.vcFormat.indent.namespaceContents": false,
+  "C_Cpp.vcFormat.indent.caseContentsWhenBlock": true,
+  "C_Cpp.vcFormat.space.pointerReferenceAlignment": "right",
+  "C_Cpp.default.browse.limitSymbolsToIncludedHeaders": false,
+  "C_Cpp.default.cppStandard": "c++20",
+  "C_Cpp.default.cStandard": "c11",
+  "C_Cpp.formatting": "clangFormat",
+  "[c]": {
+    "editor.formatOnSave": false,
+    "editor.defaultFormatter": "ms-vscode.cpptools"
+  },
+  "[cpp]": {
+    "editor.formatOnSave": false,
+    "editor.defaultFormatter": "ms-vscode.cpptools"
+  },
+  "[cuda-cpp]": {
+    "editor.defaultFormatter": "ms-vscode.cpptools"
+  },
+  "cmake.configureOnOpen": false,
+  "cmake.autoSelectActiveFolder": false,
+  "cmake.configureOnEdit": false,
+  "[cmake]": {
+    "editor.formatOnSave": false,
+    "editor.defaultFormatter": "cheshirekow.cmake-format"
+  },
+  "cmake.options.statusBarVisibility": "visible",
+  "doxdocgen.file.fileTemplate": "@file {name}",
+  "doxdocgen.cpp.tparamTemplate": "@tparam {param} ",
+  "doxdocgen.generic.briefTemplate": "@brief {text}",
+  "doxdocgen.generic.boolReturnsTrueFalse": false,
+  "doxdocgen.generic.paramTemplate": "@param {param} ",
+  "doxdocgen.generic.returnTemplate": "@return",
+  "doxdocgen.generic.includeTypeAtReturn": false,
+  "C_Cpp.codeAnalysis.clangTidy.enabled": false,
+  "C_Cpp.configurationWarnings": "disabled",
+  "C_Cpp_Runner.cppStandard": "c++20",
+  "C_Cpp_Runner.cStandard": "c11",
+  "C_Cpp_Runner.enableWarnings": true,
+  "C_Cpp_Runner.warningsAsError": false,
+  "C_Cpp_Runner.cCompilerPath": "gcc",
+  "C_Cpp_Runner.cppCompilerPath": "g++",
+  "C_Cpp_Runner.debuggerPath": "gdb",
+  "C_Cpp_Runner.useMsvc": false,
+  "C_Cpp_Runner.warnings": [
+    "-Wall",
+    "-Wextra",
+    "-Wpedantic",
+    "-Wshadow",
+    "-Wformat=2",
+    "-Wcast-align",
+    "-Wconversion",
+    "-Wsign-conversion",
+    "-Wnull-dereference"
+  ],
+  "C_Cpp_Runner.msvcWarnings": [
+    "/W4",
+    "/permissive-",
+    "/w14242",
+    "/w14287",
+    "/w14296",
+    "/w14311",
+    "/w14826",
+    "/w44062",
+    "/w44242",
+    "/w14905",
+    "/w14906",
+    "/w14263",
+    "/w44265",
+    "/w14928"
+  ],
+  "C_Cpp_Runner.compilerArgs": [],
+  "C_Cpp_Runner.linkerArgs": [],
+  "C_Cpp_Runner.includePaths": [],
+  "C_Cpp_Runner.includeSearch": [
+    "*",
+    "**/*"
+  ],
+  "C_Cpp_Runner.excludeSearch": [
+    "**/build",
+    "**/build/**",
+    "**/.*",
+    "**/.*/**",
+    "**/.vscode",
+    "**/.vscode/**"
+  ],
+  "C_Cpp_Runner.useAddressSanitizer": false,
+  "C_Cpp_Runner.useUndefinedSanitizer": false,
+  "C_Cpp_Runner.useLeakSanitizer": false,
+  "C_Cpp_Runner.showCompilationTime": false,
+  "C_Cpp_Runner.useLinkTimeOptimization": false,
+  "C_Cpp_Runner.msvcSecureNoWarnings": false,
+  "C_Cpp_Runner.msvcBatchPath": ""
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,7 +15,13 @@
 			"label": "godot-extension: Clean Build Files",
 			"detail": "Removes artifacts from the build process",
 			"type": "shell",
-			"command": "scons -C addons/glecs/cpp --clean",
+			"command": "scons --directory addons/glecs/cpp --clean",
+			"problemMatcher": []
+		}, {
+			"label": "godot-extension: Build Compilation Commands",
+			"detail": "Removes artifacts from the build process",
+			"type": "shell",
+			"command": "scons --directory addons/glecs/cpp cdb",
 			"problemMatcher": []
 		}
 	]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,13 +15,13 @@
 			"label": "godot-extension: Clean Build Files",
 			"detail": "Removes artifacts from the build process",
 			"type": "shell",
-			"command": "scons --directory addons/glecs/cpp --clean",
+			"command": "scons --clean --directory addons/glecs/cpp",
 			"problemMatcher": []
 		}, {
 			"label": "godot-extension: Build Compilation Commands",
 			"detail": "Removes artifacts from the build process",
 			"type": "shell",
-			"command": "scons --directory addons/glecs/cpp cdb",
+			"command": "scons cdb --directory addons/glecs/cpp target=template_debug debug_symbols=yes optimize=debug",
 			"problemMatcher": []
 		}
 	]

--- a/addons/glecs/cpp/SConstruct
+++ b/addons/glecs/cpp/SConstruct
@@ -6,9 +6,16 @@ from SCons.Script import *
 from SCons.Script.SConscript import SConsEnvironment
 
 env:SConsEnvironment = SConscript("include/godot-cpp/SConstruct")
+
+# Settings for speeding up compilation
 env.Decider('MD5-timestamp')
 env.SetOption('max_drift', 1)
 env.SetOption('implicit_cache', 1)
+
+# Compilation commands
+env.Tool('compilation_db')
+cdb = env.CompilationDatabase()
+Alias('cdb', cdb)
 
 platform:str = env["platform"]
 target:str = env["target"]
@@ -44,4 +51,3 @@ else:
     )
 
 env.Default(library)
-

--- a/addons/glecs/cpp/SConstruct
+++ b/addons/glecs/cpp/SConstruct
@@ -15,7 +15,9 @@ env.SetOption('implicit_cache', 1)
 # Compilation commands
 env.Tool('compilation_db')
 cdb = env.CompilationDatabase()
-Alias('cdb', cdb)
+x = env.Alias('cdb', cdb)
+if "cdb" in COMMAND_LINE_TARGETS:
+    env._dict["CXXFLAGS"].remove("-fno-gnu-unique")
 
 platform:str = env["platform"]
 target:str = env["target"]

--- a/addons/glecs/cpp/SConstruct
+++ b/addons/glecs/cpp/SConstruct
@@ -24,6 +24,8 @@ shlib_suffix:str = env["SHLIBSUFFIX"]
 # - LINKFLAGS are for linking flags
 
 # tweak this if you want to use different folders, or more folders, to store your source code in.
+env.Append(CXXFLAGS=["-fexceptions"])
+
 env.Append(CPPPATH=["src/"])
 env.Append(CPPPATH=["include/flecs/"])
 sources = env.Glob("src/*.cpp") + env.Glob("include/flecs/*.c")

--- a/addons/glecs/cpp/src/component.cpp
+++ b/addons/glecs/cpp/src/component.cpp
@@ -1,8 +1,11 @@
 
 #include "component.h"
+#include "godot_cpp/variant/array.hpp"
+#include "godot_cpp/variant/dictionary.hpp"
 #include "godot_cpp/variant/variant.hpp"
 #include "utils.h"
 
+#include <cstdint>
 #include <stdint.h>
 #include <flecs.h>
 #include <godot_cpp/core/class_db.hpp>
@@ -132,8 +135,8 @@ void GlComponent::set_member_value_as_type(
 	else if (type == GlWorld::glecs_meta_object) { SET_MEMBER(OBJECT, Variant); return; }
 	else if (type == GlWorld::glecs_meta_callable) { SET_MEMBER(CALLABLE, Callable); return; }
 	else if (type == GlWorld::glecs_meta_signal) { SET_MEMBER(SIGNAL, Signal); return; }
-	else if (type == GlWorld::glecs_meta_dictionary) { SET_MEMBER(DICTIONARY, Variant); return; }
-	else if (type == GlWorld::glecs_meta_array) { SET_MEMBER(ARRAY, Variant); return; }
+	else if (type == GlWorld::glecs_meta_dictionary) { SET_MEMBER(DICTIONARY, Dictionary); return; }
+	else if (type == GlWorld::glecs_meta_array) { SET_MEMBER(ARRAY, Array); return; }
 	else if (type == GlWorld::glecs_meta_packed_int32_array) { SET_MEMBER(PACKED_INT32_ARRAY, PackedInt32Array); return; }
 	else if (type == GlWorld::glecs_meta_packed_int64_array) { SET_MEMBER(PACKED_INT64_ARRAY, PackedInt64Array); return; }
 	else if (type == GlWorld::glecs_meta_packed_float32_array) { SET_MEMBER(PACKED_FLOAT32_ARRAY, PackedFloat32Array); return; }
@@ -269,8 +272,8 @@ Variant GlComponent::member_value_as_type(
 	else if (type == GlWorld::glecs_meta_object) { return Variant( *(Variant*) ptr ); }
 	else if (type == GlWorld::glecs_meta_callable) { return Variant( *(Callable*) ptr ); }
 	else if (type == GlWorld::glecs_meta_signal) { return Variant( *(Signal*) ptr ); }
-	else if (type == GlWorld::glecs_meta_dictionary) { return *(Variant*) ptr; }
-	else if (type == GlWorld::glecs_meta_array) { return *(Variant*) ptr; }
+	else if (type == GlWorld::glecs_meta_dictionary) { return *(Dictionary*) ptr; }
+	else if (type == GlWorld::glecs_meta_array) { return *(Array*) ptr; }
 	else if (type == GlWorld::glecs_meta_packed_int32_array) { return Variant( *(PackedInt32Array*) ptr ); }
 	else if (type == GlWorld::glecs_meta_packed_int64_array) { return Variant( *(PackedInt64Array*) ptr ); }
 	else if (type == GlWorld::glecs_meta_packed_float32_array) { return Variant( *(PackedFloat32Array*) ptr ); }

--- a/addons/glecs/cpp/src/component.cpp
+++ b/addons/glecs/cpp/src/component.cpp
@@ -1,5 +1,6 @@
 
 #include "component.h"
+#include "godot_cpp/variant/variant.hpp"
 #include "utils.h"
 
 #include <stdint.h>
@@ -22,125 +23,139 @@ void GlComponent::set_member(String member, Variant value) {
 	if (member_data == nullptr) {
 		// Member data is null. This should never happen.
 		ERR(/**/,
-			"Member data is null"
+			"Member metadata is null"
 		);
 	}
 	void* member_ptr = get_member_ptr_mut_at(member_data->offset);
-
-	const EcsPrimitive* primi = ecs_get(raw, member_data->type, EcsPrimitive);
-	if (primi == nullptr) {
-		// Member type is not a primitive
+	if (member_ptr == nullptr) {
 		ERR(/**/,
-			"Member is not a primitive. Don't know what to do."
+			"Member pointer is null"
 		);
 	}
 
-	// Return member 
-	set_member_ptr_primitive(value, member_ptr, primi->kind);
+	// Return member
+	set_member_value_as_type(member_ptr, value, member_data->type);
 }
 
-void GlComponent::set_member_ptr_primitive(
+void GlComponent::set_member_value_as_primitive(
+	void* ptr,
 	Variant value,
-	void* member,
 	ecs_primitive_kind_t primitive
 ) {
 	int8_t value_char;
 
+	#define EXPECT_VARIANT(VALUE, VARIANT_TYPE) \
+		VoidResult r = Utils::check_variant_matches(VALUE, VARIANT_TYPE); \
+		if (!r.is_ok()) { ERR(/**/, \
+			r.unwrap_err() \
+		); } \
+
+	#define SET_MEMBER(variant_type, real_type) \
+		{ \
+			EXPECT_VARIANT(value, Variant::variant_type); \
+			*(real_type*) ptr = value; \
+		}
+	#define SET_MEMBER_CHAR() \
+		{ \
+			EXPECT_VARIANT(value, Variant::INT); \
+			uint8_t intermediate = value; \
+			*(char*) ptr = intermediate; \
+		}
+	#define SET_MEMBER_ETT() \
+		{ \
+			ecs_entity_t id = get_world()->coerce_id(value); \
+			*(ecs_entity_t*) ptr = id; \
+		}
+
 	switch (primitive) {
-		case ecs_primitive_kind_t::EcsBool:
-			if (value.get_type() != Variant::BOOL) {
-				ERR(/**/, "Type mismatch");
-			}
-			*(bool*) member = value;
-			break;
-		case ecs_primitive_kind_t::EcsChar:
-			if (value.get_type() != Variant::INT) {
-				ERR(/**/, "Type mismatch");
-			}
-			value_char = value;
-			*(char*) member = value_char;
-			break;
-		case ecs_primitive_kind_t::EcsByte:
-			if (value.get_type() != Variant::INT) {
-				ERR(/**/, "Type mismatch");
-			}
-			*(uint8_t*) member = value;
-			break;
-		case ecs_primitive_kind_t::EcsU8:
-			if (value.get_type() != Variant::INT) {
-				ERR(/**/, "Type mismatch");
-			}
-			*(uint8_t*) member = value;
-			break;
-		case ecs_primitive_kind_t::EcsU16:
-			if (value.get_type() != Variant::INT) {
-				ERR(/**/, "Type mismatch");
-			}
-			*(uint16_t*) member = value;
-			break;
-		case ecs_primitive_kind_t::EcsU32:
-			if (value.get_type() != Variant::INT) {
-				ERR(/**/, "Type mismatch");
-			}
-			*(uint32_t*) member = value;
-			break;
-		case ecs_primitive_kind_t::EcsU64:
-			if (value.get_type() != Variant::INT) {
-				ERR(/**/, "Type mismatch");
-			}
-			*(uint64_t*) member = value;
-			break;
-		case ecs_primitive_kind_t::EcsI8:
-			if (value.get_type() != Variant::INT) {
-				ERR(/**/, "Type mismatch");
-			}
-			*(int8_t*) member = value;
-			break;
-		case ecs_primitive_kind_t::EcsI16:
-			if (value.get_type() != Variant::INT) {
-				ERR(/**/, "Type mismatch");
-			}
-			*(int16_t*) member = value;
-			break;
-		case ecs_primitive_kind_t::EcsI32:
-			if (value.get_type() != Variant::INT) {
-				ERR(/**/, "Type mismatch");
-			}
-			*(int32_t*) member = value;
-			break;
-		case ecs_primitive_kind_t::EcsI64:
-			if (value.get_type() != Variant::INT) {
-				ERR(/**/, "Type mismatch");
-			}
-			*(int64_t*) member = value;
-			break;
-		case ecs_primitive_kind_t::EcsF32:
-			if (value.get_type() != Variant::FLOAT) {
-					ERR(/**/, "Type mismatch");
-			}
-			*(float*) member = value;
-			break;
-		case ecs_primitive_kind_t::EcsF64:
-			if (value.get_type() != Variant::FLOAT) {
-					ERR(/**/, "Type mismatch");
-			}
-			*(double*) member = value;
-			break;
-		case ecs_primitive_kind_t::EcsString:
-			ERR(/**/, "TODO: Concerned about memory management");
-		case ecs_primitive_kind_t::EcsEntity:
-			ERR(/**/, "TODO: Implement Variant to entity ID");
-		case ecs_primitive_kind_t::EcsId:
-			ERR(/**/, "TODO: Implement Variant to entity ID");
-		case ecs_primitive_kind_t::EcsUPtr:
-			ERR(/**/, "Can't hanlde uptr");
-		case ecs_primitive_kind_t::EcsIPtr:
-			ERR(/**/, "Can't hanlde iptr");
+		case ecs_primitive_kind_t::EcsBool: SET_MEMBER(BOOL, bool); break;
+		case ecs_primitive_kind_t::EcsByte: SET_MEMBER(INT, uint8_t); break;
+		case ecs_primitive_kind_t::EcsU8: SET_MEMBER(INT, uint8_t); break;
+		case ecs_primitive_kind_t::EcsU16: SET_MEMBER(INT, uint16_t); break;
+		case ecs_primitive_kind_t::EcsU32: SET_MEMBER(INT, uint32_t); break;
+		case ecs_primitive_kind_t::EcsU64: SET_MEMBER(INT, uint64_t); break;
+		case ecs_primitive_kind_t::EcsI8: SET_MEMBER(INT, int8_t); break;
+		case ecs_primitive_kind_t::EcsI16: SET_MEMBER(INT, int16_t); break;
+		case ecs_primitive_kind_t::EcsI32: SET_MEMBER(INT, int32_t); break;
+		case ecs_primitive_kind_t::EcsI64: SET_MEMBER(INT, int64_t); break;
+		case ecs_primitive_kind_t::EcsF32: SET_MEMBER(FLOAT, float); break;
+		case ecs_primitive_kind_t::EcsF64: SET_MEMBER(FLOAT, double); break;
+		case ecs_primitive_kind_t::EcsChar: SET_MEMBER_CHAR(); break;
+		case ecs_primitive_kind_t::EcsString: ERR(/**/, "TODO: Concerned about memory management");
+		case ecs_primitive_kind_t::EcsEntity: SET_MEMBER_ETT(); break;
+		case ecs_primitive_kind_t::EcsId: SET_MEMBER_ETT(); break;
+		case ecs_primitive_kind_t::EcsUPtr: ERR(/**/, "Can't hanlde uptr");
+		case ecs_primitive_kind_t::EcsIPtr: ERR(/**/, "Can't hanlde iptr");
 		default:
-			ERR(/**/, 
+			ERR(/**/,
 				"Unhandled type"
 			);
 	}
+
+	#undef SET_MEMBER
+	#undef SET_MEMBER_CHAR
+	#undef SET_MEMBER_ETT
+}
+
+void GlComponent::set_member_value_as_type(
+	void* ptr,
+	Variant value,
+	ecs_entity_t type
+) {
+	ecs_world_t* raw = get_world()->raw();
+
+	#define SET_MEMBER(variant_type, real_type) \
+		EXPECT_VARIANT(value, Variant::variant_type); \
+		*(real_type*) ptr = value;
+
+	if (type == GlWorld::glecs_meta_real) { SET_MEMBER(FLOAT, real_t); return; }
+	else if (type == GlWorld::glecs_meta_vector2) { SET_MEMBER(VECTOR2, Vector2); return; }
+	else if (type == GlWorld::glecs_meta_vector2i) { SET_MEMBER(VECTOR2I, Vector2i); return; }
+	else if (type == GlWorld::glecs_meta_rect2) { SET_MEMBER(RECT2, Rect2); return; }
+	else if (type == GlWorld::glecs_meta_rect2i) { SET_MEMBER(RECT2I, Rect2i); return; }
+	else if (type == GlWorld::glecs_meta_vector3) { SET_MEMBER(VECTOR3, Vector3); return; }
+	else if (type == GlWorld::glecs_meta_vector3i) { SET_MEMBER(VECTOR3I, Vector3i); return; }
+	else if (type == GlWorld::glecs_meta_transform2d) { SET_MEMBER(TRANSFORM2D, Transform2D); return; }
+	else if (type == GlWorld::glecs_meta_vector4) { SET_MEMBER(VECTOR4, Vector4); return; }
+	else if (type == GlWorld::glecs_meta_vector4i) { SET_MEMBER(VECTOR4I, Vector4i); return; }
+	else if (type == GlWorld::glecs_meta_plane) { SET_MEMBER(PLANE, Plane); return; }
+	else if (type == GlWorld::glecs_meta_quaternion) { SET_MEMBER(QUATERNION, Quaternion); return; }
+	else if (type == GlWorld::glecs_meta_aabb) { SET_MEMBER(AABB, AABB); return; }
+	else if (type == GlWorld::glecs_meta_basis) { SET_MEMBER(BASIS, Basis); return; }
+	else if (type == GlWorld::glecs_meta_transform3d) { SET_MEMBER(TRANSFORM3D, Transform3D); return; }
+	else if (type == GlWorld::glecs_meta_projection) { SET_MEMBER(PROJECTION, Projection); return; }
+	else if (type == GlWorld::glecs_meta_color) { SET_MEMBER(COLOR, Color); return; }
+
+	else if (type == GlWorld::glecs_meta_string_name) { SET_MEMBER(STRING_NAME, StringName); return; }
+	else if (type == GlWorld::glecs_meta_node_path) { SET_MEMBER(NODE_PATH, NodePath); return; }
+	else if (type == GlWorld::glecs_meta_rid) { SET_MEMBER(RID, RID); return; }
+	else if (type == GlWorld::glecs_meta_object) { SET_MEMBER(OBJECT, Variant); return; }
+	else if (type == GlWorld::glecs_meta_callable) { SET_MEMBER(CALLABLE, Callable); return; }
+	else if (type == GlWorld::glecs_meta_signal) { SET_MEMBER(SIGNAL, Signal); return; }
+	else if (type == GlWorld::glecs_meta_dictionary) { SET_MEMBER(DICTIONARY, Variant); return; }
+	else if (type == GlWorld::glecs_meta_array) { SET_MEMBER(ARRAY, Variant); return; }
+	else if (type == GlWorld::glecs_meta_packed_int32_array) { SET_MEMBER(PACKED_INT32_ARRAY, PackedInt32Array); return; }
+	else if (type == GlWorld::glecs_meta_packed_int64_array) { SET_MEMBER(PACKED_INT64_ARRAY, PackedInt64Array); return; }
+	else if (type == GlWorld::glecs_meta_packed_float32_array) { SET_MEMBER(PACKED_FLOAT32_ARRAY, PackedFloat32Array); return; }
+	else if (type == GlWorld::glecs_meta_packed_float64_array) { SET_MEMBER(PACKED_FLOAT64_ARRAY, PackedFloat64Array); return; }
+	else if (type == GlWorld::glecs_meta_packed_string_array) { SET_MEMBER(PACKED_STRING_ARRAY, PackedStringArray); return; }
+	else if (type == GlWorld::glecs_meta_packed_vector2_array) { SET_MEMBER(PACKED_VECTOR2_ARRAY, PackedVector2Array); return; }
+	else if (type == GlWorld::glecs_meta_packed_vector3_array) { SET_MEMBER(PACKED_VECTOR3_ARRAY, PackedVector3Array); return; }
+	else if (type == GlWorld::glecs_meta_packed_color_array) { SET_MEMBER(PACKED_COLOR_ARRAY, PackedColorArray); return; }
+
+	if (ecs_has_id(raw, type, ecs_id(EcsPrimitive))) {
+		return set_member_value_as_primitive(
+			ptr,
+			value,
+			ecs_get(raw, type, EcsPrimitive)->kind
+		);
+	}
+
+	ERR(/**/,
+		"Can't convert type ", ecs_get_name(raw, type), " to Variant"
+	);
+
+	#undef SET_MEMBER
 }
 
 Variant GlComponent::get_member(String member) {
@@ -150,21 +165,19 @@ Variant GlComponent::get_member(String member) {
 	const EcsMember* member_data = get_member_data(member);
 	if (member_data == nullptr) {
 		// Member data is null. This should never happen.
-		ERR(nullptr, 
-			"Member data is null"
+		ERR(nullptr,
+			"Member metadata is null"
 		);
 	}
 	void* member_value_ptr = get_member_ptr_mut_at(member_data->offset);
-
-	const EcsPrimitive* primi = ecs_get(raw, member_data->type, EcsPrimitive);
-	if (primi == nullptr) {
-		// Member type is not a primitive
+	if (member_value_ptr == nullptr) {
 		ERR(nullptr,
-			"Member is not a primitive. Don't know what to do."
+			"Member value is null"
 		);
 	}
-	
-	return get_member_from_primitive(member_value_ptr, primi->kind);
+
+
+	return member_value_as_type(member_value_ptr, member_data->type);
 }
 
 void* GlComponent::get_member_ptr_mut_at(int offset) {
@@ -181,7 +194,7 @@ const EcsMember* GlComponent::get_member_data(String member) {
 	ecs_entity_t member_id = ecs_lookup_child(raw, get_id(), c_str);
 
 	if (member_id == 0) {
-		ERR(nullptr, 
+		ERR(nullptr,
 			"No member named \"",
 			member,
 			"\" found in component \"",
@@ -196,7 +209,7 @@ const EcsMember* GlComponent::get_member_data(String member) {
 	return member_data;
 }
 
-Variant GlComponent::get_member_from_primitive(
+Variant GlComponent::member_value_as_primitive(
 	void* ptr,
 	ecs_primitive_kind_t primitive
 ) {
@@ -220,10 +233,63 @@ Variant GlComponent::get_member_from_primitive(
 		case ecs_primitive_kind_t::EcsEntity: return *(ecs_entity_t*) ptr;
 		case ecs_primitive_kind_t::EcsId: return *(ecs_entity_t*) ptr;
 		default:
-			ERR(nullptr, 
-				"Unhandled type"
+			ERR(nullptr,
+				"Unknown primitive type"
 			);
 	}
+}
+
+Variant GlComponent::member_value_as_type(
+	void* ptr,
+	ecs_entity_t type
+) {
+	ecs_world_t* raw = get_world()->raw();
+
+	if (type == GlWorld::glecs_meta_real) { return Variant( *(float*) ptr );}
+	else if (type == GlWorld::glecs_meta_vector2) { return Variant( *(Vector2*) ptr ); }
+	else if (type == GlWorld::glecs_meta_vector2i) { return Variant( *(Vector2i*) ptr ); }
+	else if (type == GlWorld::glecs_meta_rect2) { return Variant( *(Rect2*) ptr ); }
+	else if (type == GlWorld::glecs_meta_rect2i) { return Variant( *(Rect2i*) ptr ); }
+	else if (type == GlWorld::glecs_meta_vector3) { return Variant( *(Vector3*) ptr ); }
+	else if (type == GlWorld::glecs_meta_vector3i) { return Variant( *(Vector3i*) ptr ); }
+	else if (type == GlWorld::glecs_meta_transform2d) { return Variant( *(Transform2D*) ptr ); }
+	else if (type == GlWorld::glecs_meta_vector4) { return Variant( *(Vector4*) ptr ); }
+	else if (type == GlWorld::glecs_meta_vector4i) { return Variant( *(Vector4i*) ptr ); }
+	else if (type == GlWorld::glecs_meta_plane) { return Variant( *(Plane*) ptr ); }
+	else if (type == GlWorld::glecs_meta_quaternion) { return Variant( *(Quaternion*) ptr ); }
+	else if (type == GlWorld::glecs_meta_aabb) { return Variant( *(AABB*) ptr ); }
+	else if (type == GlWorld::glecs_meta_basis) { return Variant( *(Basis*) ptr ); }
+	else if (type == GlWorld::glecs_meta_transform3d) { return Variant( *(Transform3D*) ptr ); }
+	else if (type == GlWorld::glecs_meta_projection) { return Variant( *(Projection*) ptr ); }
+	else if (type == GlWorld::glecs_meta_color) { return Variant( *(Color*) ptr ); }
+
+	else if (type == GlWorld::glecs_meta_string_name) { return Variant( *(StringName*) ptr ); }
+	else if (type == GlWorld::glecs_meta_node_path) { return Variant( *(NodePath*) ptr ); }
+	else if (type == GlWorld::glecs_meta_rid) { return Variant( *(RID*) ptr ); }
+	else if (type == GlWorld::glecs_meta_object) { return Variant( *(Variant*) ptr ); }
+	else if (type == GlWorld::glecs_meta_callable) { return Variant( *(Callable*) ptr ); }
+	else if (type == GlWorld::glecs_meta_signal) { return Variant( *(Signal*) ptr ); }
+	else if (type == GlWorld::glecs_meta_dictionary) { return *(Variant*) ptr; }
+	else if (type == GlWorld::glecs_meta_array) { return *(Variant*) ptr; }
+	else if (type == GlWorld::glecs_meta_packed_int32_array) { return Variant( *(PackedInt32Array*) ptr ); }
+	else if (type == GlWorld::glecs_meta_packed_int64_array) { return Variant( *(PackedInt64Array*) ptr ); }
+	else if (type == GlWorld::glecs_meta_packed_float32_array) { return Variant( *(PackedFloat32Array*) ptr ); }
+	else if (type == GlWorld::glecs_meta_packed_float64_array) { return Variant( *(PackedFloat64Array*) ptr ); }
+	else if (type == GlWorld::glecs_meta_packed_string_array) { return Variant( *(PackedStringArray*) ptr ); }
+	else if (type == GlWorld::glecs_meta_packed_vector2_array) { return Variant( *(PackedVector2Array*) ptr ); }
+	else if (type == GlWorld::glecs_meta_packed_vector3_array) { return Variant( *(PackedVector3Array*) ptr ); }
+	else if (type == GlWorld::glecs_meta_packed_color_array) { return Variant( *(PackedColorArray*) ptr ); }
+
+	if (ecs_has_id(raw, type, ecs_id(EcsPrimitive))) {
+		return member_value_as_primitive(
+			ptr,
+			ecs_get(raw, type, EcsPrimitive)->kind
+		);
+	}
+
+	ERR(nullptr,
+		"Can't convert type ", ecs_get_name(raw, type), " to Variant"
+	);
 }
 
 Ref<GlEntity> GlComponent::get_source_entity() {
@@ -245,4 +311,3 @@ void GlComponent::_bind_methods() {
 	godot::ClassDB::bind_method(D_METHOD("get_source_entity"), &GlComponent::get_source_entity);
 	godot::ClassDB::bind_method(D_METHOD("get_source_id"), &GlComponent::get_source_id);
 }
-

--- a/addons/glecs/cpp/src/component.cpp
+++ b/addons/glecs/cpp/src/component.cpp
@@ -106,57 +106,68 @@ void GlComponent::set_member_value_as_type(
 	ecs_entity_t type
 ) {
 	ecs_world_t* raw = get_world()->raw();
+	Variant::Type vari_type = get_world()->id_to_variant_type(type);
 
 	#define SET_MEMBER(variant_type, real_type) \
 		EXPECT_VARIANT(value, Variant::variant_type); \
 		*(real_type*) ptr = value;
 
-	if (type == GlWorld::glecs_meta_real) { SET_MEMBER(FLOAT, real_t); return; }
-	else if (type == GlWorld::glecs_meta_vector2) { SET_MEMBER(VECTOR2, Vector2); return; }
-	else if (type == GlWorld::glecs_meta_vector2i) { SET_MEMBER(VECTOR2I, Vector2i); return; }
-	else if (type == GlWorld::glecs_meta_rect2) { SET_MEMBER(RECT2, Rect2); return; }
-	else if (type == GlWorld::glecs_meta_rect2i) { SET_MEMBER(RECT2I, Rect2i); return; }
-	else if (type == GlWorld::glecs_meta_vector3) { SET_MEMBER(VECTOR3, Vector3); return; }
-	else if (type == GlWorld::glecs_meta_vector3i) { SET_MEMBER(VECTOR3I, Vector3i); return; }
-	else if (type == GlWorld::glecs_meta_transform2d) { SET_MEMBER(TRANSFORM2D, Transform2D); return; }
-	else if (type == GlWorld::glecs_meta_vector4) { SET_MEMBER(VECTOR4, Vector4); return; }
-	else if (type == GlWorld::glecs_meta_vector4i) { SET_MEMBER(VECTOR4I, Vector4i); return; }
-	else if (type == GlWorld::glecs_meta_plane) { SET_MEMBER(PLANE, Plane); return; }
-	else if (type == GlWorld::glecs_meta_quaternion) { SET_MEMBER(QUATERNION, Quaternion); return; }
-	else if (type == GlWorld::glecs_meta_aabb) { SET_MEMBER(AABB, AABB); return; }
-	else if (type == GlWorld::glecs_meta_basis) { SET_MEMBER(BASIS, Basis); return; }
-	else if (type == GlWorld::glecs_meta_transform3d) { SET_MEMBER(TRANSFORM3D, Transform3D); return; }
-	else if (type == GlWorld::glecs_meta_projection) { SET_MEMBER(PROJECTION, Projection); return; }
-	else if (type == GlWorld::glecs_meta_color) { SET_MEMBER(COLOR, Color); return; }
+	switch (vari_type) {
+	case(Variant::Type::NIL): {
+		if (type == GlWorld::glecs_meta_real) {
+			SET_MEMBER(FLOAT, real_t); return;
+		}
+		if (ecs_has_id(raw, type, ecs_id(EcsPrimitive))) {
+			return set_member_value_as_primitive(
+				ptr,
+				value,
+				ecs_get(raw, type, EcsPrimitive)->kind
+			);
+		}
 
-	else if (type == GlWorld::glecs_meta_string_name) { SET_MEMBER(STRING_NAME, StringName); return; }
-	else if (type == GlWorld::glecs_meta_node_path) { SET_MEMBER(NODE_PATH, NodePath); return; }
-	else if (type == GlWorld::glecs_meta_rid) { SET_MEMBER(RID, RID); return; }
-	else if (type == GlWorld::glecs_meta_object) { SET_MEMBER(OBJECT, Variant); return; }
-	else if (type == GlWorld::glecs_meta_callable) { SET_MEMBER(CALLABLE, Callable); return; }
-	else if (type == GlWorld::glecs_meta_signal) { SET_MEMBER(SIGNAL, Signal); return; }
-	else if (type == GlWorld::glecs_meta_dictionary) { SET_MEMBER(DICTIONARY, Dictionary); return; }
-	else if (type == GlWorld::glecs_meta_array) { SET_MEMBER(ARRAY, Array); return; }
-	else if (type == GlWorld::glecs_meta_packed_int32_array) { SET_MEMBER(PACKED_INT32_ARRAY, PackedInt32Array); return; }
-	else if (type == GlWorld::glecs_meta_packed_int64_array) { SET_MEMBER(PACKED_INT64_ARRAY, PackedInt64Array); return; }
-	else if (type == GlWorld::glecs_meta_packed_float32_array) { SET_MEMBER(PACKED_FLOAT32_ARRAY, PackedFloat32Array); return; }
-	else if (type == GlWorld::glecs_meta_packed_float64_array) { SET_MEMBER(PACKED_FLOAT64_ARRAY, PackedFloat64Array); return; }
-	else if (type == GlWorld::glecs_meta_packed_string_array) { SET_MEMBER(PACKED_STRING_ARRAY, PackedStringArray); return; }
-	else if (type == GlWorld::glecs_meta_packed_vector2_array) { SET_MEMBER(PACKED_VECTOR2_ARRAY, PackedVector2Array); return; }
-	else if (type == GlWorld::glecs_meta_packed_vector3_array) { SET_MEMBER(PACKED_VECTOR3_ARRAY, PackedVector3Array); return; }
-	else if (type == GlWorld::glecs_meta_packed_color_array) { SET_MEMBER(PACKED_COLOR_ARRAY, PackedColorArray); return; }
-
-	if (ecs_has_id(raw, type, ecs_id(EcsPrimitive))) {
-		return set_member_value_as_primitive(
-			ptr,
-			value,
-			ecs_get(raw, type, EcsPrimitive)->kind
+		ERR(/**/,
+			"Can't set member\nType ", ecs_get_name(raw, type), " is not handled"
 		);
 	}
-
-	ERR(/**/,
-		"Can't convert type ", ecs_get_name(raw, type), " to Variant"
-	);
+	case(Variant::Type::BOOL): { SET_MEMBER(BOOL, bool); return; }
+	case(Variant::Type::INT): { SET_MEMBER(INT, int64_t); return; }
+	case(Variant::Type::FLOAT): { SET_MEMBER(FLOAT, float); return; }
+	case(Variant::Type::STRING): { SET_MEMBER(STRING, String); return; }
+	case(Variant::Type::VECTOR2): { SET_MEMBER(VECTOR2, Vector2); return; }
+	case(Variant::Type::VECTOR2I): { SET_MEMBER(VECTOR2I, Vector2i); return; }
+	case(Variant::Type::RECT2): { SET_MEMBER(RECT2, Rect2); return; }
+	case(Variant::Type::RECT2I): { SET_MEMBER(RECT2I, Rect2i); return; }
+	case(Variant::Type::VECTOR3): { SET_MEMBER(VECTOR3, Vector3); return; }
+	case(Variant::Type::VECTOR3I): { SET_MEMBER(VECTOR3I, Vector3i); return; }
+	case(Variant::Type::TRANSFORM2D): { SET_MEMBER(TRANSFORM2D, Transform2D); return; }
+	case(Variant::Type::VECTOR4): { SET_MEMBER(VECTOR4, Vector4); return; }
+	case(Variant::Type::VECTOR4I): { SET_MEMBER(VECTOR4I, Vector4i); return; }
+	case(Variant::Type::PLANE): { SET_MEMBER(PLANE, Plane); return; }
+	case(Variant::Type::QUATERNION): { SET_MEMBER(QUATERNION, Quaternion); return; }
+	case(Variant::Type::AABB): { SET_MEMBER(AABB, AABB); return; }
+	case(Variant::Type::BASIS): { SET_MEMBER(BASIS, Basis); return; }
+	case(Variant::Type::TRANSFORM3D): { SET_MEMBER(TRANSFORM3D, Transform3D); return; }
+	case(Variant::Type::PROJECTION): { SET_MEMBER(PROJECTION, Projection); return; }
+	case(Variant::Type::COLOR): { SET_MEMBER(COLOR, Color); return; }
+	case(Variant::Type::STRING_NAME): { SET_MEMBER(STRING_NAME, StringName); return; }
+	case(Variant::Type::NODE_PATH): { SET_MEMBER(NODE_PATH, NodePath); return; }
+	case(Variant::Type::RID): { SET_MEMBER(RID, RID); return; }
+	case(Variant::Type::OBJECT): { SET_MEMBER(OBJECT, Variant); return; }
+	case(Variant::Type::CALLABLE): { SET_MEMBER(CALLABLE, Callable); return; }
+	case(Variant::Type::SIGNAL): { SET_MEMBER(SIGNAL, Signal); return; }
+	case(Variant::Type::DICTIONARY): { SET_MEMBER(DICTIONARY, Dictionary); return; }
+	case(Variant::Type::ARRAY): { SET_MEMBER(ARRAY, Array); return; }
+	case(Variant::Type::PACKED_BYTE_ARRAY): { SET_MEMBER(PACKED_BYTE_ARRAY, PackedByteArray); return; }
+	case(Variant::Type::PACKED_INT32_ARRAY): { SET_MEMBER(PACKED_INT32_ARRAY, PackedInt32Array); return; }
+	case(Variant::Type::PACKED_INT64_ARRAY): { SET_MEMBER(PACKED_INT64_ARRAY, PackedInt64Array); return; }
+	case(Variant::Type::PACKED_FLOAT32_ARRAY): { SET_MEMBER(PACKED_FLOAT32_ARRAY, PackedFloat32Array); return; }
+	case(Variant::Type::PACKED_FLOAT64_ARRAY): { SET_MEMBER(PACKED_FLOAT64_ARRAY, PackedFloat64Array); return; }
+	case(Variant::Type::PACKED_STRING_ARRAY): { SET_MEMBER(PACKED_STRING_ARRAY, PackedStringArray); return; }
+	case(Variant::Type::PACKED_VECTOR2_ARRAY): { SET_MEMBER(PACKED_VECTOR2_ARRAY, PackedVector2Array); return; }
+	case(Variant::Type::PACKED_VECTOR3_ARRAY): { SET_MEMBER(PACKED_VECTOR3_ARRAY, PackedVector3Array); return; }
+	case(Variant::Type::PACKED_COLOR_ARRAY): { SET_MEMBER(PACKED_COLOR_ARRAY, PackedColorArray); return; }
+	case(Variant::Type::VARIANT_MAX): throw "Can't set set member\\nVARIANt_MAX is not a valid type";
+	}
 
 	#undef SET_MEMBER
 }
@@ -230,15 +241,12 @@ Variant GlComponent::member_value_as_primitive(
 		case ecs_primitive_kind_t::EcsI64: return *(int64_t*) ptr;
 		case ecs_primitive_kind_t::EcsF32: return *(float*) ptr;
 		case ecs_primitive_kind_t::EcsF64: return *(double*) ptr;
-		case ecs_primitive_kind_t::EcsUPtr: ERR(nullptr, "Can't hanlde uptr");
-		case ecs_primitive_kind_t::EcsIPtr: ERR(nullptr, "Can't hanlde iptr");
+		case ecs_primitive_kind_t::EcsUPtr: ERR(nullptr, "Can't get primitive\nCan't hanlde uptr");
+		case ecs_primitive_kind_t::EcsIPtr: ERR(nullptr, "Can't get primitive\nCan't hanlde iptr");
 		case ecs_primitive_kind_t::EcsString: return *(char**) ptr;
 		case ecs_primitive_kind_t::EcsEntity: return *(ecs_entity_t*) ptr;
 		case ecs_primitive_kind_t::EcsId: return *(ecs_entity_t*) ptr;
-		default:
-			ERR(nullptr,
-				"Unknown primitive type"
-			);
+		default: ERR(nullptr, "Can't get primitive\nUnknown primitive type");
 	}
 }
 
@@ -247,52 +255,63 @@ Variant GlComponent::member_value_as_type(
 	ecs_entity_t type
 ) {
 	ecs_world_t* raw = get_world()->raw();
+	Variant::Type vari_type = get_world()->id_to_variant_type(type);
 
-	if (type == GlWorld::glecs_meta_real) { return Variant( *(float*) ptr );}
-	else if (type == GlWorld::glecs_meta_vector2) { return Variant( *(Vector2*) ptr ); }
-	else if (type == GlWorld::glecs_meta_vector2i) { return Variant( *(Vector2i*) ptr ); }
-	else if (type == GlWorld::glecs_meta_rect2) { return Variant( *(Rect2*) ptr ); }
-	else if (type == GlWorld::glecs_meta_rect2i) { return Variant( *(Rect2i*) ptr ); }
-	else if (type == GlWorld::glecs_meta_vector3) { return Variant( *(Vector3*) ptr ); }
-	else if (type == GlWorld::glecs_meta_vector3i) { return Variant( *(Vector3i*) ptr ); }
-	else if (type == GlWorld::glecs_meta_transform2d) { return Variant( *(Transform2D*) ptr ); }
-	else if (type == GlWorld::glecs_meta_vector4) { return Variant( *(Vector4*) ptr ); }
-	else if (type == GlWorld::glecs_meta_vector4i) { return Variant( *(Vector4i*) ptr ); }
-	else if (type == GlWorld::glecs_meta_plane) { return Variant( *(Plane*) ptr ); }
-	else if (type == GlWorld::glecs_meta_quaternion) { return Variant( *(Quaternion*) ptr ); }
-	else if (type == GlWorld::glecs_meta_aabb) { return Variant( *(AABB*) ptr ); }
-	else if (type == GlWorld::glecs_meta_basis) { return Variant( *(Basis*) ptr ); }
-	else if (type == GlWorld::glecs_meta_transform3d) { return Variant( *(Transform3D*) ptr ); }
-	else if (type == GlWorld::glecs_meta_projection) { return Variant( *(Projection*) ptr ); }
-	else if (type == GlWorld::glecs_meta_color) { return Variant( *(Color*) ptr ); }
+	switch (vari_type) {
+	case(Variant::Type::NIL): {
+		// Member is not a Godot type. Try to get from Flecs primitive
+		if (ecs_has_id(raw, type, ecs_id(EcsPrimitive))) {
+			return member_value_as_primitive(
+				ptr,
+				ecs_get(raw, type, EcsPrimitive)->kind
+			);
+		}
 
-	else if (type == GlWorld::glecs_meta_string_name) { return Variant( *(StringName*) ptr ); }
-	else if (type == GlWorld::glecs_meta_node_path) { return Variant( *(NodePath*) ptr ); }
-	else if (type == GlWorld::glecs_meta_rid) { return Variant( *(RID*) ptr ); }
-	else if (type == GlWorld::glecs_meta_object) { return Variant( *(Variant*) ptr ); }
-	else if (type == GlWorld::glecs_meta_callable) { return Variant( *(Callable*) ptr ); }
-	else if (type == GlWorld::glecs_meta_signal) { return Variant( *(Signal*) ptr ); }
-	else if (type == GlWorld::glecs_meta_dictionary) { return *(Dictionary*) ptr; }
-	else if (type == GlWorld::glecs_meta_array) { return *(Array*) ptr; }
-	else if (type == GlWorld::glecs_meta_packed_int32_array) { return Variant( *(PackedInt32Array*) ptr ); }
-	else if (type == GlWorld::glecs_meta_packed_int64_array) { return Variant( *(PackedInt64Array*) ptr ); }
-	else if (type == GlWorld::glecs_meta_packed_float32_array) { return Variant( *(PackedFloat32Array*) ptr ); }
-	else if (type == GlWorld::glecs_meta_packed_float64_array) { return Variant( *(PackedFloat64Array*) ptr ); }
-	else if (type == GlWorld::glecs_meta_packed_string_array) { return Variant( *(PackedStringArray*) ptr ); }
-	else if (type == GlWorld::glecs_meta_packed_vector2_array) { return Variant( *(PackedVector2Array*) ptr ); }
-	else if (type == GlWorld::glecs_meta_packed_vector3_array) { return Variant( *(PackedVector3Array*) ptr ); }
-	else if (type == GlWorld::glecs_meta_packed_color_array) { return Variant( *(PackedColorArray*) ptr ); }
-
-	if (ecs_has_id(raw, type, ecs_id(EcsPrimitive))) {
-		return member_value_as_primitive(
-			ptr,
-			ecs_get(raw, type, EcsPrimitive)->kind
+		ERR(nullptr,
+			"Can't convert type ", ecs_get_name(raw, type), " to Variant"
 		);
 	}
+	case(Variant::Type::BOOL): return Variant( *(bool*) ptr );
+	case(Variant::Type::INT): return Variant( *(int64_t*) ptr );
+	case(Variant::Type::FLOAT): return Variant( *(float*) ptr );
+	case(Variant::Type::STRING): return Variant( *(String*) ptr );
+	case(Variant::Type::VECTOR2): return Variant( *(Vector2*) ptr );
+	case(Variant::Type::VECTOR2I): return Variant( *(Vector2i*) ptr );
+	case(Variant::Type::RECT2): return Variant( *(Rect2*) ptr );
+	case(Variant::Type::RECT2I): return Variant( *(Rect2i*) ptr );
+	case(Variant::Type::VECTOR3): return Variant( *(Vector3*) ptr );
+	case(Variant::Type::VECTOR3I): return Variant( *(Vector3i*) ptr );
+	case(Variant::Type::TRANSFORM2D): return Variant( *(Transform2D*) ptr );
+	case(Variant::Type::VECTOR4): return Variant( *(Vector4*) ptr );
+	case(Variant::Type::VECTOR4I): return Variant( *(Vector4i*) ptr );
+	case(Variant::Type::PLANE): return Variant( *(Plane*) ptr );
+	case(Variant::Type::QUATERNION): return Variant( *(Quaternion*) ptr );
+	case(Variant::Type::AABB): return Variant( *(AABB*) ptr );
+	case(Variant::Type::BASIS): return Variant( *(Basis*) ptr );
+	case(Variant::Type::TRANSFORM3D): return Variant( *(Transform3D*) ptr );
+	case(Variant::Type::PROJECTION): return Variant( *(Projection*) ptr );
+	case(Variant::Type::COLOR): return Variant( *(Color*) ptr );
+	case(Variant::Type::STRING_NAME): return Variant( *(StringName*) ptr );
+	case(Variant::Type::NODE_PATH): return Variant( *(NodePath*) ptr );
+	case(Variant::Type::RID): return Variant( *(RID*) ptr );
+	case(Variant::Type::OBJECT): return Variant( *(Variant*) ptr );
+	case(Variant::Type::CALLABLE): return Variant( *(Callable*) ptr );
+	case(Variant::Type::SIGNAL): return Variant( *(Signal*) ptr );
+	case(Variant::Type::DICTIONARY): return *(Dictionary*) ptr;
+	case(Variant::Type::ARRAY): return *(Array*) ptr;
+	case(Variant::Type::PACKED_BYTE_ARRAY): return Variant( *(PackedByteArray*) ptr );
+	case(Variant::Type::PACKED_INT32_ARRAY): return Variant( *(PackedInt32Array*) ptr );
+	case(Variant::Type::PACKED_INT64_ARRAY): return Variant( *(PackedInt64Array*) ptr );
+	case(Variant::Type::PACKED_FLOAT32_ARRAY): return Variant( *(PackedFloat32Array*) ptr );
+	case(Variant::Type::PACKED_FLOAT64_ARRAY): return Variant( *(PackedFloat64Array*) ptr );
+	case(Variant::Type::PACKED_STRING_ARRAY): return Variant( *(PackedStringArray*) ptr );
+	case(Variant::Type::PACKED_VECTOR2_ARRAY): return Variant( *(PackedVector2Array*) ptr );
+	case(Variant::Type::PACKED_VECTOR3_ARRAY): return Variant( *(PackedVector3Array*) ptr );
+	case(Variant::Type::PACKED_COLOR_ARRAY): return Variant( *(PackedColorArray*) ptr );
+	case(Variant::Type::VARIANT_MAX): throw "Can't get type VARIANT_MAX";
+	}
 
-	ERR(nullptr,
-		"Can't convert type ", ecs_get_name(raw, type), " to Variant"
-	);
+	throw "Unreachable";
 }
 
 Ref<GlEntity> GlComponent::get_source_entity() {

--- a/addons/glecs/cpp/src/component.h
+++ b/addons/glecs/cpp/src/component.h
@@ -18,11 +18,19 @@ namespace godot {
 		GlComponent();
 		~GlComponent();
 
+		// --------------------------------------
+		// --- Exposed
+		// --------------------------------------
+
 		Variant get_member(String);
 		void set_member(String, Variant);
 
 		Ref<GlEntity> get_source_entity();
 		ecs_entity_t get_source_id();
+
+		// --------------------------------------
+		// --- Unexposed
+		// --------------------------------------
 
 		void set_source_id(ecs_entity_t id);
 
@@ -31,13 +39,13 @@ namespace godot {
 
 		void* get_member_ptr_mut_at(int offset);
 		const EcsMember* get_member_data(String);
-		
+
 		Variant member_value_as_primitive(void*, ecs_primitive_kind_t);
 		Variant member_value_as_type(void*, ecs_entity_t);
 		void set_member_value_as_primitive(void*, Variant, ecs_primitive_kind_t);
 		void set_member_value_as_type(void*, Variant, ecs_entity_t);
 
-	
+
 	private:
 		ecs_entity_t source_entity_id;
 	};

--- a/addons/glecs/cpp/src/component.h
+++ b/addons/glecs/cpp/src/component.h
@@ -32,8 +32,10 @@ namespace godot {
 		void* get_member_ptr_mut_at(int offset);
 		const EcsMember* get_member_data(String);
 		
-		Variant get_member_from_primitive(void*, ecs_primitive_kind_t);
-		void set_member_ptr_primitive(Variant, void*, ecs_primitive_kind_t);
+		Variant member_value_as_primitive(void*, ecs_primitive_kind_t);
+		Variant member_value_as_type(void*, ecs_entity_t);
+		void set_member_value_as_primitive(void*, Variant, ecs_primitive_kind_t);
+		void set_member_value_as_type(void*, Variant, ecs_entity_t);
 
 	
 	private:

--- a/addons/glecs/cpp/src/component_builder.cpp
+++ b/addons/glecs/cpp/src/component_builder.cpp
@@ -1,0 +1,119 @@
+
+
+#include "component_builder.h"
+#include "world.h"
+#include "utils.h"
+
+#include <flecs.h>
+
+using namespace godot;
+
+GlComponentBuilder::GlComponentBuilder() {
+	component_desc = {0};
+	struct_desc = {0};
+	member_names = Array();
+	world = {0};
+	built = {0};
+}
+GlComponentBuilder::~GlComponentBuilder() {
+}
+
+Ref<GlComponentBuilder> GlComponentBuilder::add_member(
+	String member,
+	Variant::Type type
+) {
+	const char* ERR_ADD_COMPONENT = "Failed to add member to component builder\n";
+
+	if (get_member_count() == ECS_MEMBER_DESC_CACHE_SIZE) {
+		ERR(Ref(this),
+			ERR_ADD_COMPONENT,
+			"Max member count reached"
+		);
+	}
+
+	EntityResult ecs_type_result = Utils::variant_type_to_id(type);
+	if (!ecs_type_result.is_ok()) {
+		ERR(Ref(this),
+			ERR_ADD_COMPONENT,
+			ecs_type_result.unwrap_err()
+		);
+	}
+	ecs_entity_t ecs_type = ecs_type_result.unwrap();
+
+	struct_desc.members[get_member_count()] = {
+		.type = ecs_type
+	};
+	member_names.append(member);
+
+	return Ref(this);
+}
+
+int GlComponentBuilder::get_member_count() {
+	return member_names.size();
+}
+
+Ref<GlComponentBuilder> GlComponentBuilder::set_name(
+	String name_
+) {
+	name = name_;
+	return Ref(this);
+}
+
+void GlComponentBuilder::build() {
+	const char* FAILED_TO_BUILD = "Failed to build component\n";
+	if (built) {
+		ERR(/**/,
+			FAILED_TO_BUILD,
+			"Component builder was already built"
+		);
+	}
+	built = true;
+
+	// Set names to temporary pointers
+	CharString name_utf8 = name.utf8();
+	CharString member_names_utf8[ECS_MEMBER_DESC_CACHE_SIZE] = {0};
+	component_desc.type.name = name_utf8.ptr();
+	for (int i=0; i != get_member_count(); i++) {
+		member_names_utf8[i] = String(member_names[i]).utf8();
+		struct_desc.members[i].name = member_names_utf8[i].ptr();
+	}
+
+	ecs_world_t* raw = world->raw();
+
+	// Create component entity
+	ecs_entity_t component_id = ecs_new_from_path(raw, 0, component_desc.type.name);
+	component_desc.entity = component_id;
+	struct_desc.entity = component_id;
+
+	ecs_entity_t struct_id = ecs_struct_init(raw, &struct_desc);
+
+	// Set size of component
+	const EcsStruct* struct_data = ecs_get(raw, struct_id, EcsStruct);
+	const ecs_member_t* final_member = ecs_vec_last_t(
+		&struct_data->members,
+		ecs_member_t
+	);
+	component_desc.type.size = final_member->offset + final_member->size;
+	component_desc.type.alignment = 8;
+
+	ecs_component_init(raw, &component_desc);
+}
+
+void GlComponentBuilder:: set_world(GlWorld* world_) {
+	world = world_;
+}
+
+// **********************************************
+// *** PROTECTED ***
+// **********************************************
+
+void GlComponentBuilder::_bind_methods() {
+	godot::ClassDB::bind_method(D_METHOD("add_member", "member", "type"), &GlComponentBuilder::add_member);
+	godot::ClassDB::bind_method(D_METHOD("set_name", "name"), &GlComponentBuilder::set_name);
+	godot::ClassDB::bind_method(D_METHOD("build"), &GlComponentBuilder::build);
+
+}
+
+// **********************************************
+// *** PRIVATE ***
+// **********************************************

--- a/addons/glecs/cpp/src/component_builder.cpp
+++ b/addons/glecs/cpp/src/component_builder.cpp
@@ -86,17 +86,6 @@ void GlComponentBuilder::build() {
 	struct_desc.entity = component_id;
 
 	ecs_entity_t struct_id = ecs_struct_init(raw, &struct_desc);
-
-	// Set size of component
-	const EcsStruct* struct_data = ecs_get(raw, struct_id, EcsStruct);
-	const ecs_member_t* final_member = ecs_vec_last_t(
-		&struct_data->members,
-		ecs_member_t
-	);
-	component_desc.type.size = final_member->offset + final_member->size;
-	component_desc.type.alignment = 8;
-
-	ecs_component_init(raw, &component_desc);
 }
 
 void GlComponentBuilder:: set_world(GlWorld* world_) {

--- a/addons/glecs/cpp/src/component_builder.cpp
+++ b/addons/glecs/cpp/src/component_builder.cpp
@@ -32,7 +32,7 @@ Ref<GlComponentBuilder> GlComponentBuilder::add_member(
 		);
 	}
 
-	EntityResult ecs_type_result = Utils::variant_type_to_id(type);
+	EntityResult ecs_type_result = GlWorld::variant_type_to_id(type);
 	if (!ecs_type_result.is_ok()) {
 		ERR(Ref(this),
 			ERR_ADD_COMPONENT,

--- a/addons/glecs/cpp/src/component_builder.h
+++ b/addons/glecs/cpp/src/component_builder.h
@@ -49,6 +49,10 @@ namespace godot {
 		bool built;
 
 		static void ctor(void*, int32_t, const ecs_type_info_t*);
+		static void dtor(void*, int32_t, const ecs_type_info_t*);
+		static void copy(void*, const void*, int32_t, const ecs_type_info_t*);
+		static void move(void*, void*, int32_t, const ecs_type_info_t*);
+
 	};
 
 	class HooksBindingContext {

--- a/addons/glecs/cpp/src/component_builder.h
+++ b/addons/glecs/cpp/src/component_builder.h
@@ -47,6 +47,16 @@ namespace godot {
 		GlWorld* world;
 		/// Is true if this builder has already been built
 		bool built;
+
+		static void ctor(void*, int32_t, const ecs_type_info_t*);
+	};
+
+	class HooksBindingContext {
+	public:
+		GlWorld* world;
+
+		HooksBindingContext(GlWorld* world);
+		~HooksBindingContext();
 	};
 
 }

--- a/addons/glecs/cpp/src/component_builder.h
+++ b/addons/glecs/cpp/src/component_builder.h
@@ -1,0 +1,54 @@
+
+#ifndef COMPONENT_Builder_H
+#define COMPONENT_Builder_H
+
+#include <flecs.h>
+#include <godot_cpp/classes/ref_counted.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+namespace godot {
+
+	// Predefine instead of include to avoid cyclic dependencies
+	class GlWorld;
+
+	class GlComponentBuilder : public RefCounted {
+		GDCLASS(GlComponentBuilder, RefCounted)
+
+	public:
+		GlComponentBuilder();
+		~GlComponentBuilder();
+
+		// **************************************
+		// *** Exposed ***
+		// **************************************
+
+		Ref<GlComponentBuilder> add_member(String, Variant::Type);
+		int get_member_count();
+		Ref<GlComponentBuilder> set_name(String);
+		void build();
+
+		// **************************************
+		// *** Unexposed ***
+		// **************************************
+
+		void set_world(GlWorld*);
+
+	protected:
+		static void _bind_methods();
+
+	private:
+		ecs_component_desc_t component_desc;
+		ecs_struct_desc_t struct_desc;
+		/// @brief A list of the allocated names of members
+		/// Also used to find the number of added of members
+		Array member_names;
+		/// The name of this compoennt
+		String name;
+		GlWorld* world;
+		/// Is true if this builder has already been built
+		bool built;
+	};
+
+}
+
+#endif

--- a/addons/glecs/cpp/src/entity.cpp
+++ b/addons/glecs/cpp/src/entity.cpp
@@ -47,21 +47,7 @@ Ref<GlEntity> GlEntity::from(Variant entity, GlWorld* world) {
 Ref<GlEntity> GlEntity::add_component(Variant component) {
 	GlWorld* w = get_world();
 	ecs_entity_t component_id = w->coerce_id(component);
-	UtilityFunctions::print("compoefm ", component_id, ", ", component);
-	ecs_add_id(
-		w->raw(),
-		get_id(),
-		component_id
-	);
-
-	// if (ecs_has(w->raw(), component_id, EcsComponent)) {
-	// 	// Id is a component, initialize newly added component
-	// 	w->init_component_ptr(
-	// 		ecs_get_mut_id(w->raw(), get_id(), component_id),
-	// 		component_id,
-	// 		Variant()
-	// 	);
-	// }
+	ecs_add_id(w->raw(), get_id(), component_id);
 
 	return Ref(this);
 }

--- a/addons/glecs/cpp/src/entity.cpp
+++ b/addons/glecs/cpp/src/entity.cpp
@@ -1,6 +1,5 @@
 
-#include <iostream>
-
+#include "godot_cpp/variant/variant.hpp"
 #include "utils.h"
 #include "entity.h"
 // needed here because entity.h does not include
@@ -41,13 +40,29 @@ Ref<GlEntity> GlEntity::from(Variant entity, GlWorld* world) {
 	if (!e->is_alive()) {
 		return Variant(nullptr);
 	}
-	
+
 	return e;
 }
 
 Ref<GlEntity> GlEntity::add_component(Variant component) {
 	GlWorld* w = get_world();
-	ecs_add_id(w->raw(), get_id(), w->coerce_id(component));
+	ecs_entity_t component_id = w->coerce_id(component);
+	UtilityFunctions::print("compoefm ", component_id, ", ", component);
+	ecs_add_id(
+		w->raw(),
+		get_id(),
+		component_id
+	);
+
+	// if (ecs_has(w->raw(), component_id, EcsComponent)) {
+	// 	// Id is a component, initialize newly added component
+	// 	w->init_component_ptr(
+	// 		ecs_get_mut_id(w->raw(), get_id(), component_id),
+	// 		component_id,
+	// 		Variant()
+	// 	);
+	// }
+
 	return Ref(this);
 }
 
@@ -67,7 +82,7 @@ Ref<GlComponent> GlEntity::get_component(Variant component) {
 			"Could not find attached component ID ", component_id, " on entity"
 		);
 	}
-	
+
 	c->set_source_id(id);
 
 	return c;
@@ -82,6 +97,10 @@ bool GlEntity::is_alive() {
 ecs_entity_t GlEntity::get_id() { return id; }
 GlWorld* GlEntity::get_world() { return world; }
 
+// ----------------------------------------------
+// --- Unexposed ---
+// ----------------------------------------------
+
 void GlEntity::set_id(ecs_entity_t value) { id = value; }
 void GlEntity::set_world(GlWorld* value) { world = value; }
 
@@ -95,4 +114,3 @@ void GlEntity::_bind_methods() {
 	godot::ClassDB::bind_method(D_METHOD("get_id"), &GlEntity::get_id);
 	godot::ClassDB::bind_method(D_METHOD("get_world"), &GlEntity::get_world);
 }
-

--- a/addons/glecs/cpp/src/entity.h
+++ b/addons/glecs/cpp/src/entity.h
@@ -24,7 +24,7 @@ namespace godot {
 
 		Ref<GlEntity> add_component(Variant);
 		Ref<GlComponent> get_component(Variant);
-		
+
 		bool is_alive();
 
 		ecs_entity_t get_id();
@@ -35,7 +35,7 @@ namespace godot {
 
 	protected:
 		static void _bind_methods();
-	
+
 	private:
 		ecs_entity_t id;
 		GlWorld* world;

--- a/addons/glecs/cpp/src/entity.h
+++ b/addons/glecs/cpp/src/entity.h
@@ -19,6 +19,10 @@ namespace godot {
 		GlEntity();
 		~GlEntity();
 
+		// --------------------------------------
+		// --- Exposed ---
+		// --------------------------------------
+
 		static Ref<GlEntity> spawn(GlWorld*);
 		static Ref<GlEntity> from(Variant, GlWorld*);
 
@@ -29,6 +33,10 @@ namespace godot {
 
 		ecs_entity_t get_id();
 		GlWorld* get_world();
+
+		// --------------------------------------
+		// --- Unexposed ---
+		// --------------------------------------
 
 		void set_id(ecs_entity_t);
 		void set_world(GlWorld*);

--- a/addons/glecs/cpp/src/entity.h
+++ b/addons/glecs/cpp/src/entity.h
@@ -9,9 +9,7 @@
 
 namespace godot {
 
-	// Forward declare GlComponent instead of including component.h to avoid
-	// cyclic dependncies that causes GlComponent to compile before GlEntity
-	// is defined.
+	// Predefine instead of include to avoid cyclic dependencies
 	class GlComponent;
 
 	class GlEntity : public RefCounted {

--- a/addons/glecs/cpp/src/register_types.cpp
+++ b/addons/glecs/cpp/src/register_types.cpp
@@ -5,6 +5,7 @@
 #include "entity.h"
 #include "registerable_entity.h"
 #include "component.h"
+#include "component_builder.h"
 
 #include <gdextension_interface.h>
 #include <godot_cpp/core/defs.hpp>
@@ -24,6 +25,7 @@ void initialize_module(ModuleInitializationLevel p_level) {
 	godot::ClassDB::register_class<GlEntity>();
 	godot::ClassDB::register_class<GlRegisterableEntity>();
 	godot::ClassDB::register_class<GlComponent>();
+	godot::ClassDB::register_abstract_class<GlComponentBuilder>();
 
 	Engine::get_singleton()->register_singleton("GlGlobalWorld", memnew(GlWorld));
 }

--- a/addons/glecs/cpp/src/utils.cpp
+++ b/addons/glecs/cpp/src/utils.cpp
@@ -1,5 +1,6 @@
 
 #include "utils.h"
+#include "world.h"
 
 #include <flecs.h>
 
@@ -8,10 +9,25 @@ using namespace godot;
 /// Converts a godot::Variant::Type to Flecs's closest Entity type
 EntityResult Utils::variant_type_to_id(Variant::Type type) {
 	switch (type) {
-		case Variant::BOOL:
-			return EntityResult::Ok(ecs_id(ecs_bool_t));
-		case Variant::INT:
-			return EntityResult::Ok(ecs_id(ecs_i64_t));
+		case Variant::BOOL: return EntityResult::Ok(ecs_id(ecs_bool_t));
+		case Variant::INT: return EntityResult::Ok(ecs_id(ecs_i64_t));
+		case Variant::FLOAT: return EntityResult::Ok(ecs_id(ecs_f64_t));
+		case Variant::VECTOR2: return EntityResult::Ok(GlWorld::glecs_meta_vector2);
+		case Variant::VECTOR2I: return EntityResult::Ok(GlWorld::glecs_meta_vector2i);
+		case Variant::RECT2: return EntityResult::Ok(GlWorld::glecs_meta_rect2);
+		case Variant::RECT2I: return EntityResult::Ok(GlWorld::glecs_meta_rect2i);
+		case Variant::VECTOR3: return EntityResult::Ok(GlWorld::glecs_meta_vector3);
+		case Variant::VECTOR3I: return EntityResult::Ok(GlWorld::glecs_meta_vector3i);
+		case Variant::TRANSFORM2D: return EntityResult::Ok(GlWorld::glecs_meta_transform2d);
+		case Variant::VECTOR4: return EntityResult::Ok(GlWorld::glecs_meta_vector4);
+		case Variant::VECTOR4I: return EntityResult::Ok(GlWorld::glecs_meta_vector4i);
+		case Variant::PLANE: return EntityResult::Ok(GlWorld::glecs_meta_plane);
+		case Variant::QUATERNION: return EntityResult::Ok(GlWorld::glecs_meta_quaternion);
+		case Variant::AABB: return EntityResult::Ok(GlWorld::glecs_meta_aabb);
+		case Variant::BASIS: return EntityResult::Ok(GlWorld::glecs_meta_basis);
+		case Variant::TRANSFORM3D: return EntityResult::Ok(GlWorld::glecs_meta_transform3d);
+		case Variant::PROJECTION: return EntityResult::Ok(GlWorld::glecs_meta_projection);
+		case Variant::COLOR: return EntityResult::Ok(GlWorld::glecs_meta_color);
 		
 		default:
 			return EntityResult::Err(

--- a/addons/glecs/cpp/src/utils.cpp
+++ b/addons/glecs/cpp/src/utils.cpp
@@ -1,0 +1,23 @@
+
+#include "utils.h"
+
+#include <flecs.h>
+
+using namespace godot;
+
+/// Converts a godot::Variant::Type to Flecs's closest Entity type
+EntityResult Utils::variant_type_to_id(Variant::Type type) {
+	switch (type) {
+		case Variant::BOOL:
+			return EntityResult::Ok(ecs_id(ecs_bool_t));
+		case Variant::INT:
+			return EntityResult::Ok(ecs_id(ecs_i64_t));
+		
+		default:
+			return EntityResult::Err(
+				String("Could not convert Variant type ")
+				+ Variant::get_type_name(type)
+				+ " to entity ID"
+			);
+	}
+}

--- a/addons/glecs/cpp/src/utils.cpp
+++ b/addons/glecs/cpp/src/utils.cpp
@@ -29,6 +29,23 @@ EntityResult Utils::variant_type_to_id(Variant::Type type) {
 		case Variant::PROJECTION: return EntityResult::Ok(GlWorld::glecs_meta_projection);
 		case Variant::COLOR: return EntityResult::Ok(GlWorld::glecs_meta_color);
 		
+		case Variant::STRING_NAME: return EntityResult::Ok(GlWorld::glecs_meta_string_name);
+		case Variant::NODE_PATH: return EntityResult::Ok(GlWorld::glecs_meta_node_path);
+		case Variant::RID: return EntityResult::Ok(GlWorld::glecs_meta_rid);
+		case Variant::OBJECT: return EntityResult::Ok(GlWorld::glecs_meta_object);
+		case Variant::CALLABLE: return EntityResult::Ok(GlWorld::glecs_meta_callable);
+		case Variant::SIGNAL: return EntityResult::Ok(GlWorld::glecs_meta_signal);
+		case Variant::DICTIONARY: return EntityResult::Ok(GlWorld::glecs_meta_dictionary);
+		case Variant::ARRAY: return EntityResult::Ok(GlWorld::glecs_meta_array);
+		case Variant::PACKED_INT32_ARRAY: return EntityResult::Ok(GlWorld::glecs_meta_packed_int32_array);
+		case Variant::PACKED_INT64_ARRAY: return EntityResult::Ok(GlWorld::glecs_meta_packed_int64_array);
+		case Variant::PACKED_FLOAT32_ARRAY: return EntityResult::Ok(GlWorld::glecs_meta_packed_float32_array);
+		case Variant::PACKED_FLOAT64_ARRAY: return EntityResult::Ok(GlWorld::glecs_meta_packed_float64_array);
+		case Variant::PACKED_STRING_ARRAY: return EntityResult::Ok(GlWorld::glecs_meta_packed_string_array);
+		case Variant::PACKED_VECTOR2_ARRAY: return EntityResult::Ok(GlWorld::glecs_meta_packed_vector2_array);
+		case Variant::PACKED_VECTOR3_ARRAY: return EntityResult::Ok(GlWorld::glecs_meta_packed_vector3_array);
+		case Variant::PACKED_COLOR_ARRAY: return EntityResult::Ok(GlWorld::glecs_meta_packed_color_array);
+		
 		default:
 			return EntityResult::Err(
 				String("Could not convert Variant type ")

--- a/addons/glecs/cpp/src/utils.h
+++ b/addons/glecs/cpp/src/utils.h
@@ -14,13 +14,11 @@ template <typename T, typename E>
 class Result {
 
 public:
-	Result(T value_) {
+	Result(T value_): value(value_) {
 		_is_ok = true;
-		value = value_;
 	}
-	Result(E error_) {
+	Result(E error_): error(error_) {
 		_is_ok = false;
-		error = error_;
 	}
 	~Result() {
 		if (is_ok()) {
@@ -61,11 +59,31 @@ private:
     };
 };
 
+#define CHECK_VARIANT(VALUE, VARIANT_TYPE) \
+		if (value.get_type() != VARIANT_TYPE) { ERR(/**/, \
+			"Expected variant value, ", VALUE, ", to be of type ", \
+			Variant::get_type_name(VARIANT_TYPE), \
+			", but is of type ", Variant::get_type_name(VALUE.get_type()) \
+		); } \
+
 namespace godot {
 	typedef Result<ecs_entity_t, String> EntityResult;
+	typedef Result<int8_t, String> VoidResult;
 
 	class Utils {
 	public:
+		static VoidResult check_variant_matches(Variant value, Variant::Type type) {
+			if (value.get_type() != type) {
+				return VoidResult(
+					String("Expected variant value \"") + String(value)
+					+ String("\" to be of type ") + Variant::get_type_name(type)
+					+ String(", but it is of type ")
+					+ Variant::get_type_name(value.get_type())
+				);
+			}
+			return VoidResult::Ok(0);
+		}
+
 		/// Converts a Variant::Type to an Entity ID
 		static EntityResult variant_type_to_id(Variant::Type type);
 

--- a/addons/glecs/cpp/src/utils.h
+++ b/addons/glecs/cpp/src/utils.h
@@ -9,4 +9,55 @@
 	UtilityFunctions::push_error(__VA_ARGS__); \
 	return return_value;
 
+template <typename T, typename E>
+class Result {
+
+public:
+	Result(T value_) {
+		_is_ok = true;
+		value = value_;
+	}
+	Result(E error_) {
+		_is_ok = false;
+		error = error_;
+	}
+	~Result() {
+		if (is_ok()) {
+			value.~T();
+		} else {
+			error.~E();
+		}
+	}
+
+	static Result Ok(T value) {
+		return Result(value);
+	}
+	static Result Err(E error) {
+		return Result(error);
+	}
+
+	bool is_ok() {
+		return _is_ok;
+	}
+	T unwrap() {
+		if (!is_ok()) {
+			throw "Tried to convert Error to Ok";
+		}
+		return value;
+	};
+	E unwrap_err() {
+		if (is_ok()) {
+			throw "Tried to convert Ok to Error";
+		}
+		return error;
+	};
+
+private:
+	bool _is_ok;
+	union {
+        T value;
+        E error;
+    };
+};
+
 #endif

--- a/addons/glecs/cpp/src/utils.h
+++ b/addons/glecs/cpp/src/utils.h
@@ -2,6 +2,7 @@
 #ifndef GLECS_UTILS_H
 #define GLECS_UTILS_H
 
+#include <flecs.h>
 #include <godot_cpp/variant/utility_functions.hpp>
 
 #define ERR(return_value, ...) \
@@ -59,5 +60,17 @@ private:
         E error;
     };
 };
+
+namespace godot {
+	typedef Result<ecs_entity_t, String> EntityResult;
+
+	class Utils {
+	public:
+		/// Converts a Variant::Type to an Entity ID
+		static EntityResult variant_type_to_id(Variant::Type type);
+
+	};
+
+}
 
 #endif

--- a/addons/glecs/cpp/src/world.cpp
+++ b/addons/glecs/cpp/src/world.cpp
@@ -5,6 +5,7 @@
 #include "godot_cpp/core/memory.hpp"
 #include "godot_cpp/variant/dictionary.hpp"
 #include "godot_cpp/variant/utility_functions.hpp"
+#include "godot_cpp/variant/variant.hpp"
 #include "utils.h"
 
 #include <flecs.h>
@@ -17,6 +18,11 @@ using namespace godot;
 ecs_entity_t GlWorld::glecs = 0;
 ecs_entity_t GlWorld::glecs_meta = 0;
 ecs_entity_t GlWorld::glecs_meta_real = 0;
+ecs_entity_t GlWorld::glecs_meta_nil = 0;
+ecs_entity_t GlWorld::glecs_meta_bool = 0;
+ecs_entity_t GlWorld::glecs_meta_int = 0;
+ecs_entity_t GlWorld::glecs_meta_float = 0;
+ecs_entity_t GlWorld::glecs_meta_string = 0;
 ecs_entity_t GlWorld::glecs_meta_vector2 = 0;
 ecs_entity_t GlWorld::glecs_meta_vector2i = 0;
 ecs_entity_t GlWorld::glecs_meta_rect2 = 0;
@@ -41,6 +47,7 @@ ecs_entity_t GlWorld::glecs_meta_callable = 0;
 ecs_entity_t GlWorld::glecs_meta_signal = 0;
 ecs_entity_t GlWorld::glecs_meta_dictionary = 0;
 ecs_entity_t GlWorld::glecs_meta_array = 0;
+ecs_entity_t GlWorld::glecs_meta_packed_byte_array = 0;
 ecs_entity_t GlWorld::glecs_meta_packed_int32_array = 0;
 ecs_entity_t GlWorld::glecs_meta_packed_int64_array = 0;
 ecs_entity_t GlWorld::glecs_meta_packed_float32_array = 0;
@@ -79,8 +86,7 @@ GlWorld::GlWorld() {
 		ecs_set_scope(_raw, old_scope);
 	}
 
-	{
-		// Add glecs/meta/Real type
+	{ // Add glecs/meta/Real type
 		ecs_primitive_kind_t kind;
 		if (sizeof(real_t) == sizeof(float)) {
 			kind = ecs_primitive_kind_t::EcsF32;
@@ -96,125 +102,223 @@ GlWorld::GlWorld() {
 		glecs_meta_real = ecs_primitive_init(_raw, &primi_desc);
 	}
 
-	{
-		// Add glecs/meta/Vector2 type
+	glecs_meta_nil = ecs_new(_raw);
+	glecs_meta_bool = ecs_new(_raw);
+	glecs_meta_int = ecs_new(_raw);
+	glecs_meta_float = ecs_new(_raw);
+	glecs_meta_string = ecs_new(_raw);
+	glecs_meta_vector2 = ecs_new(_raw);
+	glecs_meta_vector2i = ecs_new(_raw);
+	glecs_meta_rect2 = ecs_new(_raw);
+	glecs_meta_rect2i = ecs_new(_raw);
+	glecs_meta_vector3 = ecs_new(_raw);
+	glecs_meta_vector3i = ecs_new(_raw);
+	glecs_meta_transform2d = ecs_new(_raw);
+	glecs_meta_vector4 = ecs_new(_raw);
+	glecs_meta_vector4i = ecs_new(_raw);
+	glecs_meta_plane = ecs_new(_raw);
+	glecs_meta_quaternion = ecs_new(_raw);
+	glecs_meta_aabb = ecs_new(_raw);
+	glecs_meta_basis = ecs_new(_raw);
+	glecs_meta_transform3d = ecs_new(_raw);
+	glecs_meta_projection = ecs_new(_raw);
+	glecs_meta_color = ecs_new(_raw);
+	glecs_meta_string_name = ecs_new(_raw);
+	glecs_meta_node_path = ecs_new(_raw);
+	glecs_meta_rid = ecs_new(_raw);
+	glecs_meta_object = ecs_new(_raw);
+	glecs_meta_callable = ecs_new(_raw);
+	glecs_meta_signal = ecs_new(_raw);
+	glecs_meta_dictionary = ecs_new(_raw);
+	glecs_meta_array = ecs_new(_raw);
+	glecs_meta_packed_byte_array = ecs_new(_raw);
+	glecs_meta_packed_int32_array = ecs_new(_raw);
+	glecs_meta_packed_int64_array = ecs_new(_raw);
+	glecs_meta_packed_float32_array = ecs_new(_raw);
+	glecs_meta_packed_float64_array = ecs_new(_raw);
+	glecs_meta_packed_string_array = ecs_new(_raw);
+	glecs_meta_packed_vector2_array = ecs_new(_raw);
+	glecs_meta_packed_vector3_array = ecs_new(_raw);
+	glecs_meta_packed_color_array = ecs_new(_raw);
+
+	define_gd_literal("nil", ecs_primitive_kind_t::EcsUPtr, &glecs_meta_nil);
+	define_gd_literal("bool", ecs_primitive_kind_t::EcsBool, &glecs_meta_bool);
+	define_gd_literal("int", ecs_primitive_kind_t::EcsI64, &glecs_meta_int);
+	define_gd_literal("float", ecs_primitive_kind_t::EcsF64, &glecs_meta_float);
+	define_gd_component<String>("String", &glecs_meta_string);
+
+	{ // Add glecs/meta/Vector2 type
 		ecs_struct_desc_t desc = {
-			.entity = ecs_new_from_path(_raw, glecs_meta, "Vector2"),
+			.entity = glecs_meta_vector2,
 			.members = {
 				{.name = "x", .type = glecs_meta_real},
 				{.name = "y", .type = glecs_meta_real}
 			}
-		};
-		glecs_meta_vector2 = ecs_struct_init(_raw, &desc);
+		}; ecs_struct_init(_raw, &desc);
+		ecs_add_path_w_sep(
+			_raw,
+			glecs_meta_vector2,
+			glecs_meta,
+			"Vector2",
+			"/",
+			"/root/"
+		);
 	}
 
-	{
-		// Add glecs/meta/Vector2i type
+	{ // Add glecs/meta/Vector2i type
 		ecs_struct_desc_t desc = {
-			.entity = ecs_new_from_path(_raw, glecs_meta, "Vector2i"),
+			.entity = glecs_meta_vector2i,
 			.members = {
 				{.name = "x", .type = ecs_id(ecs_i32_t)},
 				{.name = "y", .type = ecs_id(ecs_i32_t)}
 			}
-		};
-		glecs_meta_vector2i = ecs_struct_init(_raw, &desc);
+		}; ecs_struct_init(_raw, &desc);
+		ecs_add_path_w_sep(
+			_raw,
+			glecs_meta_vector2i,
+			glecs_meta,
+			"Vector2I",
+			"/",
+			"/root/"
+		);
 	}
 
-	{
-		// Add glecs/meta/Rect type
+	{ // Add glecs/meta/Rect type
 		ecs_struct_desc_t desc = {
-			.entity = ecs_new_from_path(_raw, glecs_meta, "Rect2"),
+			.entity = glecs_meta_rect2,
 			.members = {
 				{.name = "position", .type = glecs_meta_vector2},
 				{.name = "size", .type = glecs_meta_vector2}
 			}
-		};
-		glecs_meta_rect2 = ecs_struct_init(_raw, &desc);
+		}; ecs_struct_init(_raw, &desc);
+		ecs_add_path_w_sep(
+			_raw,
+			glecs_meta_rect2,
+			glecs_meta,
+			"Rect2",
+			"/",
+			"/root/"
+		);
 	}
 
-	{
-		// Add glecs/meta/Rect2i type
+	{ // Add glecs/meta/Rect2i type
 		ecs_struct_desc_t desc = {
-			.entity = ecs_new_from_path(_raw, glecs_meta, "Rect2i"),
+			.entity = glecs_meta_rect2i,
 			.members = {
 				{.name = "position", .type = glecs_meta_vector2i},
 				{.name = "size", .type = glecs_meta_vector2i}
 			}
-		};
-		glecs_meta_rect2i = ecs_struct_init(_raw, &desc);
+		}; ecs_struct_init(_raw, &desc);
+		ecs_add_path_w_sep(
+			_raw,
+			glecs_meta_rect2i,
+			glecs_meta,
+			"Rect2i",
+			"/",
+			"/root/"
+		);
 	}
 
-	{
-		// Add glecs/meta/Vector3 type
+	{ // Add glecs/meta/Vector3 type
 		ecs_struct_desc_t desc = {
-			.entity = ecs_new_from_path(_raw, glecs_meta, "Vector3"),
+			.entity = glecs_meta_vector3,
 			.members = {
 				{.name = "x", .type = glecs_meta_real},
 				{.name = "y", .type = glecs_meta_real},
 				{.name = "z", .type = glecs_meta_real}
 			}
-		};
-		glecs_meta_vector3 = ecs_struct_init(_raw, &desc);
+		}; ecs_struct_init(_raw, &desc);
+		ecs_add_path_w_sep(
+			_raw,
+			glecs_meta_vector3,
+			glecs_meta,
+			"Vector3",
+			"/",
+			"/root/"
+		);
 	}
 
-	{
-		// Add glecs/meta/Vector3i type
+	{ // Add glecs/meta/Vector3i type
 		ecs_struct_desc_t desc = {
-			.entity = ecs_new_from_path(_raw, glecs_meta, "Vector3i"),
+			.entity = glecs_meta_vector3i,
 			.members = {
 				{.name = "x", .type = ecs_id(ecs_i32_t)},
 				{.name = "y", .type = ecs_id(ecs_i32_t)},
 				{.name = "z", .type = ecs_id(ecs_i32_t)}
 			}
-		};
-		glecs_meta_vector3i = ecs_struct_init(_raw, &desc);
+		}; ecs_struct_init(_raw, &desc);
+		ecs_add_path_w_sep(
+			_raw,
+			glecs_meta_vector3i,
+			glecs_meta,
+			"Vector3i",
+			"/",
+			"/root/"
+		);
 	}
 
-	{
-		// Add glecs/meta/Transform2D type
+	{ // Add glecs/meta/Transform2D type
 		ecs_struct_desc_t desc = {
-			.entity = ecs_new_from_path(_raw, glecs_meta, "Transform2D"),
+			.entity = glecs_meta_transform2d,
 			.members = {
 				{.name = "x", .type = glecs_meta_vector2},
 				{.name = "y", .type = glecs_meta_vector2},
 				{.name = "origin", .type = glecs_meta_vector2}
 			}
-		};
-		glecs_meta_transform2d = ecs_struct_init(_raw, &desc);
+		}; ecs_struct_init(_raw, &desc);
+		ecs_add_path_w_sep(
+			_raw,
+			glecs_meta_transform2d,
+			glecs_meta,
+			"Transform2D",
+			"/",
+			"/root/"
+		);
 	}
 
-	{
-		// Add glecs/meta/Vector4 type
+	{ // Add glecs/meta/Vector4 type
 		ecs_struct_desc_t desc = {
-			.entity = ecs_new_from_path(_raw, glecs_meta, "Vector4"),
+			.entity = glecs_meta_vector4,
 			.members = {
 				{.name = "x", .type = glecs_meta_real},
 				{.name = "y", .type = glecs_meta_real},
 				{.name = "z", .type = glecs_meta_real},
 				{.name = "w", .type = glecs_meta_real}
 			}
-		};
-		glecs_meta_vector4 = ecs_struct_init(_raw, &desc);
+		}; ecs_struct_init(_raw, &desc);
+		ecs_add_path_w_sep(
+			_raw,
+			glecs_meta_vector4,
+			glecs_meta,
+			"Vector4",
+			"/",
+			"/root/"
+		);
 	}
 
-	{
-		// Add glecs/meta/Vector4i type
+	{ // Add glecs/meta/Vector4i type
 		ecs_struct_desc_t desc = {
-			.entity = ecs_new_from_path(_raw, glecs_meta, "Vector4i"),
+			.entity = glecs_meta_vector4i,
 			.members = {
 				{.name = "x", .type = ecs_id(ecs_i32_t)},
 				{.name = "y", .type = ecs_id(ecs_i32_t)},
 				{.name = "z", .type = ecs_id(ecs_i32_t)},
 				{.name = "w", .type = ecs_id(ecs_i32_t)}
 			}
-		};
-		glecs_meta_vector4i = ecs_struct_init(_raw, &desc);
+		}; ecs_struct_init(_raw, &desc);
+		ecs_add_path_w_sep(
+			_raw,
+			glecs_meta_vector4i,
+			glecs_meta,
+			"Vector4i",
+			"/",
+			"/root/"
+		);
 	}
 
-	{
-		// Add glecs/meta/Plane type
+	{ // Add glecs/meta/Plane type
 		ecs_struct_desc_t desc = {
-			.entity = ecs_new_from_path(_raw, glecs_meta, "Plane"),
+			.entity = glecs_meta_plane,
 			.members = {
 				{.name = "x", .type = glecs_meta_real},
 				{.name = "y", .type = glecs_meta_real},
@@ -222,87 +326,130 @@ GlWorld::GlWorld() {
 				{.name = "d", .type = glecs_meta_real},
 				{.name = "normal", .type = glecs_meta_vector3}
 			}
-		};
-		glecs_meta_plane = ecs_struct_init(_raw, &desc);
+		}; ecs_struct_init(_raw, &desc);
+		ecs_add_path_w_sep(
+			_raw,
+			glecs_meta_plane,
+			glecs_meta,
+			"Plane",
+			"/",
+			"/root/"
+		);
 	}
 
-	{
-		// Add glecs/meta/Quaternion type
+	{ // Add glecs/meta/Quaternion type
 		ecs_struct_desc_t desc = {
-			.entity = ecs_new_from_path(_raw, glecs_meta, "Quaternion"),
+			.entity = glecs_meta_quaternion,
 			.members = {
 				{.name = "x", .type = glecs_meta_real},
 				{.name = "y", .type = glecs_meta_real},
 				{.name = "z", .type = glecs_meta_real},
 				{.name = "w", .type = glecs_meta_real}
 			}
-		};
-		glecs_meta_quaternion = ecs_struct_init(_raw, &desc);
+		}; ecs_struct_init(_raw, &desc);
+		ecs_add_path_w_sep(
+			_raw,
+			glecs_meta_quaternion,
+			glecs_meta,
+			"Quaternion",
+			"/",
+			"/root/"
+		);
 	}
 
-	{
-		// Add glecs/meta/AABB type
+	{ // Add glecs/meta/AABB type
 		ecs_struct_desc_t desc = {
-			.entity = ecs_new_from_path(_raw, glecs_meta, "AABB"),
+			.entity = glecs_meta_aabb,
 			.members = {
 				{.name = "position", .type = glecs_meta_vector3},
 				{.name = "size", .type = glecs_meta_vector3}
 			}
-		};
-		glecs_meta_aabb = ecs_struct_init(_raw, &desc);
+		}; ecs_struct_init(_raw, &desc);
+		ecs_add_path_w_sep(
+			_raw,
+			glecs_meta_aabb,
+			glecs_meta,
+			"AABB",
+			"/",
+			"/root/"
+		);
 	}
 
-	{
-		// Add glecs/meta/Basis type
+	{ // Add glecs/meta/Basis type
 		ecs_struct_desc_t desc = {
-			.entity = ecs_new_from_path(_raw, glecs_meta, "Basis"),
+			.entity = glecs_meta_basis,
 			.members = {
 				{.name = "x", .type = glecs_meta_vector3},
 				{.name = "y", .type = glecs_meta_vector3},
 				{.name = "z", .type = glecs_meta_vector3}
 			}
-		};
-		glecs_meta_basis = ecs_struct_init(_raw, &desc);
+		}; ecs_struct_init(_raw, &desc);
+		ecs_add_path_w_sep(
+			_raw,
+			glecs_meta_basis,
+			glecs_meta,
+			"Basis",
+			"/",
+			"/root/"
+		);
 	}
 
-	{
-		// Add glecs/meta/Transform3D type
+	{ // Add glecs/meta/Transform3D type
 		ecs_struct_desc_t desc = {
-			.entity = ecs_new_from_path(_raw, glecs_meta, "Transform3D"),
+			.entity = glecs_meta_transform3d,
 			.members = {
 				{.name = "basis", .type = glecs_meta_basis},
 				{.name = "origin", .type = glecs_meta_vector3}
 			}
-		};
-		glecs_meta_transform3d = ecs_struct_init(_raw, &desc);
+		}; ecs_struct_init(_raw, &desc);
+		ecs_add_path_w_sep(
+			_raw,
+			glecs_meta_transform3d,
+			glecs_meta,
+			"Transform3D",
+			"/",
+			"/root/"
+		);
 	}
 
-	{
-		// Add glecs/meta/Projection type
+	{ // Add glecs/meta/Projection type
 		ecs_struct_desc_t desc = {
-			.entity = ecs_new_from_path(_raw, glecs_meta, "Projection"),
+			.entity = glecs_meta_projection,
 			.members = {
 				{.name = "x", .type = glecs_meta_vector4},
 				{.name = "y", .type = glecs_meta_vector4},
 				{.name = "z", .type = glecs_meta_vector4},
 				{.name = "w", .type = glecs_meta_vector4}
 			}
-		};
-		glecs_meta_projection = ecs_struct_init(_raw, &desc);
+		}; ecs_struct_init(_raw, &desc);
+		ecs_add_path_w_sep(
+			_raw,
+			glecs_meta_projection,
+			glecs_meta,
+			"Projection",
+			"/",
+			"/root/"
+		);
 	}
 
-	{
-		// Add glecs/meta/Color type
+	{ // Add glecs/meta/Color type
 		ecs_struct_desc_t desc = {
-			.entity = ecs_new_from_path(_raw, glecs_meta, "Color"),
+			.entity = glecs_meta_color,
 			.members = {
 				{.name = "r", .type = ecs_id(ecs_f32_t)},
 				{.name = "g", .type = ecs_id(ecs_f32_t)},
 				{.name = "b", .type = ecs_id(ecs_f32_t)},
 				{.name = "a", .type = ecs_id(ecs_f32_t)}
 			}
-		};
-		glecs_meta_color = ecs_struct_init(_raw, &desc);
+		}; ecs_struct_init(_raw, &desc);
+		ecs_add_path_w_sep(
+			_raw,
+			glecs_meta_color,
+			glecs_meta,
+			"Color",
+			"/",
+			"/root/"
+		);
 	}
 
 	define_gd_component<StringName>("StringName", &glecs_meta_string_name);
@@ -313,6 +460,7 @@ GlWorld::GlWorld() {
 	define_gd_component<Signal>("Signal", &glecs_meta_signal);
 	define_gd_component<Dictionary>("Dictionary", &glecs_meta_dictionary);
 	define_gd_component<Array>("Array", &glecs_meta_array);
+	define_gd_component<PackedByteArray>("PackedByteArray", &glecs_meta_packed_byte_array);
 	define_gd_component<PackedInt32Array>("PackedInt32Array", &glecs_meta_packed_int32_array);
 	define_gd_component<PackedInt64Array>("PackedInt64Array", &glecs_meta_packed_int64_array);
 	define_gd_component<PackedFloat32Array>("PackedFloat32Array", &glecs_meta_packed_float32_array);
@@ -396,6 +544,24 @@ void GlWorld::start_rest_api() {
 	ecs_set_id(raw(), rest_id, rest_id, sizeof(EcsRest), &rest);
 }
 
+ecs_entity_t GlWorld::variant_type_to_id(Variant::Type type) {
+	if (type == Variant::Type::VARIANT_MAX) {
+		throw "No ID exists for VARIANT_MAX";
+	}
+	return GlWorld::glecs_meta_nil + type;
+}
+
+Variant::Type GlWorld::id_to_variant_type(ecs_entity_t id) {
+	if (id < GlWorld::glecs_meta_nil) {
+		return godot::Variant::NIL;
+	}
+	Variant::Type type = Variant::Type(id - GlWorld::glecs_meta_nil);
+	if (type >= Variant::Type::VARIANT_MAX) {
+		return godot::Variant::NIL;
+	}
+	return type;
+}
+
 // ----------------------------------------------
 // --- Unexposed ---
 // ----------------------------------------------
@@ -421,40 +587,49 @@ void GlWorld::init_gd_type_ptr(
 	void* ptr,
 	ecs_entity_t type
 ) {
-	if (type == GlWorld::glecs_meta_vector2) { new(ptr) Vector2(); }
-	else if (type == GlWorld::glecs_meta_vector2i) { new(ptr) Vector2i(); }
-	else if (type == GlWorld::glecs_meta_rect2) { new(ptr) Rect2(); }
-	else if (type == GlWorld::glecs_meta_rect2i) { new(ptr) Rect2i(); }
-	else if (type == GlWorld::glecs_meta_vector3) { new(ptr) Vector3(); }
-	else if (type == GlWorld::glecs_meta_vector3i) { new(ptr) Vector3i(); }
-	else if (type == GlWorld::glecs_meta_transform2d) { new(ptr) Transform2D(); }
-	else if (type == GlWorld::glecs_meta_vector4) { new(ptr) Vector4(); }
-	else if (type == GlWorld::glecs_meta_vector4i) { new(ptr) Vector4i(); }
-	else if (type == GlWorld::glecs_meta_plane) { new(ptr) Plane(); }
-	else if (type == GlWorld::glecs_meta_quaternion) { new(ptr) Quaternion(); }
-	else if (type == GlWorld::glecs_meta_aabb) { new(ptr) AABB(); }
-	else if (type == GlWorld::glecs_meta_basis) { new(ptr) Basis(); }
-	else if (type == GlWorld::glecs_meta_transform3d) { new(ptr) Transform3D(); }
-	else if (type == GlWorld::glecs_meta_projection) { new(ptr) Projection(); }
-	else if (type == GlWorld::glecs_meta_color) { new(ptr) Color(); }
-	else if (type == GlWorld::glecs_meta_string_name) { new(ptr) StringName(); }
-	else if (type == GlWorld::glecs_meta_node_path) { new(ptr) NodePath(); }
-	else if (type == GlWorld::glecs_meta_rid) { new(ptr) RID(); }
-	else if (type == GlWorld::glecs_meta_object) { *(Object**)ptr = nullptr ; }
-	else if (type == GlWorld::glecs_meta_callable) { new(ptr) Callable(); }
-	else if (type == GlWorld::glecs_meta_signal) { new(ptr) Signal(); }
-	else if (type == GlWorld::glecs_meta_dictionary) { new(ptr) Dictionary(); }
-	else if (type == GlWorld::glecs_meta_array) { new(ptr) Array(); }
-	else if (type == GlWorld::glecs_meta_packed_int32_array) { new(ptr) PackedInt32Array(); }
-	else if (type == GlWorld::glecs_meta_packed_int64_array) { new(ptr) PackedInt64Array(); }
-	else if (type == GlWorld::glecs_meta_packed_float32_array) { new(ptr) PackedFloat32Array(); }
-	else if (type == GlWorld::glecs_meta_packed_float64_array) { new(ptr) PackedFloat64Array(); }
-	else if (type == GlWorld::glecs_meta_packed_string_array) { new(ptr) PackedStringArray(); }
-	else if (type == GlWorld::glecs_meta_packed_vector2_array) { new(ptr) PackedVector2Array(); }
-	else if (type == GlWorld::glecs_meta_packed_vector3_array) { new(ptr) PackedVector3Array(); }
-	else if (type == GlWorld::glecs_meta_packed_color_array) { new(ptr) PackedColorArray(); }
+	Variant::Type vari_type = id_to_variant_type(type);
 
-	else if (ecs_has(_raw, type, EcsStruct)) { init_component_ptr(ptr, type, Variant()); }
+	switch (vari_type) {
+	case(Variant::Type::NIL): if (ecs_has(_raw, type, EcsStruct)) {init_component_ptr(ptr, type, Variant());}; break;
+	case(Variant::Type::BOOL): *(bool*) ptr = false; break;
+	case(Variant::Type::INT): *(int*) ptr = 0; break;
+	case(Variant::Type::FLOAT): *(float*) ptr = 0; break;
+	case(Variant::Type::STRING): new(ptr) String(); break;
+	case(Variant::Type::VECTOR2): new(ptr) Vector2(); break;
+	case(Variant::Type::VECTOR2I): new(ptr) Vector2i(); break;
+	case(Variant::Type::RECT2): new(ptr) Rect2(); break;
+	case(Variant::Type::RECT2I): new(ptr) Rect2i(); break;
+	case(Variant::Type::VECTOR3): new(ptr) Vector3(); break;
+	case(Variant::Type::VECTOR3I): new(ptr) Vector3i(); break;
+	case(Variant::Type::TRANSFORM2D): new(ptr) Transform2D(); break;
+	case(Variant::Type::VECTOR4): new(ptr) Vector4(); break;
+	case(Variant::Type::VECTOR4I): new(ptr) Vector4i(); break;
+	case(Variant::Type::PLANE): new(ptr) Plane(); break;
+	case(Variant::Type::QUATERNION): new(ptr) Quaternion(); break;
+	case(Variant::Type::AABB): new(ptr) AABB(); break;
+	case(Variant::Type::BASIS): new(ptr) Basis(); break;
+	case(Variant::Type::TRANSFORM3D): new(ptr) Transform3D(); break;
+	case(Variant::Type::PROJECTION): new(ptr) Projection(); break;
+	case(Variant::Type::COLOR): new(ptr) Color(); break;
+	case(Variant::Type::STRING_NAME): new(ptr) StringName(); break;
+	case(Variant::Type::NODE_PATH): new(ptr) NodePath(); break;
+	case(Variant::Type::RID): new(ptr) RID(); break;
+	case(Variant::Type::OBJECT): *(Variant*)ptr = nullptr ; break;
+	case(Variant::Type::CALLABLE): new(ptr) Callable(); break;
+	case(Variant::Type::SIGNAL): new(ptr) Signal(); break;
+	case(Variant::Type::DICTIONARY): new(ptr) Dictionary(); break;
+	case(Variant::Type::ARRAY): new(ptr) Array(); break;
+	case(Variant::Type::PACKED_BYTE_ARRAY): new(ptr) PackedByteArray(); break;
+	case(Variant::Type::PACKED_INT32_ARRAY): new(ptr) PackedInt32Array(); break;
+	case(Variant::Type::PACKED_INT64_ARRAY): new(ptr) PackedInt64Array(); break;
+	case(Variant::Type::PACKED_FLOAT32_ARRAY): new(ptr) PackedFloat32Array(); break;
+	case(Variant::Type::PACKED_FLOAT64_ARRAY): new(ptr) PackedFloat64Array(); break;
+	case(Variant::Type::PACKED_STRING_ARRAY): new(ptr) PackedStringArray(); break;
+	case(Variant::Type::PACKED_VECTOR2_ARRAY): new(ptr) PackedVector2Array(); break;
+	case(Variant::Type::PACKED_VECTOR3_ARRAY): new(ptr) PackedVector3Array(); break;
+	case(Variant::Type::PACKED_COLOR_ARRAY): new(ptr) PackedColorArray(); break;
+	case(Variant::Type::VARIANT_MAX): throw "VARIANT_MAX can't be initialized";
+	}
 }
 
 ecs_world_t * GlWorld::raw() {
@@ -475,3 +650,22 @@ void GlWorld::_bind_methods() {
 // ----------------------------------------------
 // --- Private ---
 // ----------------------------------------------
+
+void GlWorld::define_gd_literal(
+	const char* name,
+	ecs_primitive_kind_t primitive,
+	ecs_entity_t* id_storage
+) {
+	ecs_primitive_desc_t desc = {
+		.entity = *id_storage,
+		.kind = primitive
+	}; ecs_primitive_init(_raw, &desc);
+	ecs_add_path_w_sep(
+		_raw,
+		*id_storage,
+		glecs_meta,
+		name,
+		"/",
+		"/root/"
+	);
+}

--- a/addons/glecs/cpp/src/world.cpp
+++ b/addons/glecs/cpp/src/world.cpp
@@ -1,6 +1,7 @@
 
 #include "world.h"
 #include "entity.h"
+#include "component_builder.h"
 #include "utils.h"
 
 #include <flecs.h>
@@ -73,6 +74,12 @@ static GlWorld* singleton() {
 	return Object::cast_to<GlWorld>(singleton);
 }
 
+Ref<GlComponentBuilder> GlWorld::component_builder() {
+	Ref<GlComponentBuilder> builder = memnew(GlComponentBuilder);
+	builder->set_world(this);
+	return builder;
+}
+
 void GlWorld::start_rest_api() {
 	ecs_entity_t rest_id = ecs_lookup_path_w_sep(raw(), 0, "flecs.rest.Rest", ".", "", false);
 	EcsRest rest = (EcsRest)EcsRest();
@@ -84,6 +91,7 @@ ecs_world_t * GlWorld::raw() {
 }
 
 void GlWorld::_bind_methods() {
+	godot::ClassDB::bind_method(D_METHOD("component_builder"), &GlWorld::component_builder);
 	godot::ClassDB::bind_method(D_METHOD("coerce_id", "entity"), &GlWorld::coerce_id);
 	godot::ClassDB::bind_method(D_METHOD("start_rest_api"), &GlWorld::start_rest_api);
 	godot::ClassDB::bind_method(D_METHOD("progress", "delta"), &GlWorld::progress);

--- a/addons/glecs/cpp/src/world.cpp
+++ b/addons/glecs/cpp/src/world.cpp
@@ -30,6 +30,22 @@ ecs_entity_t GlWorld::glecs_meta_basis = 0;
 ecs_entity_t GlWorld::glecs_meta_transform3d = 0;
 ecs_entity_t GlWorld::glecs_meta_projection = 0;
 ecs_entity_t GlWorld::glecs_meta_color = 0;
+ecs_entity_t GlWorld::glecs_meta_string_name = 0;
+ecs_entity_t GlWorld::glecs_meta_node_path = 0;
+ecs_entity_t GlWorld::glecs_meta_rid = 0;
+ecs_entity_t GlWorld::glecs_meta_object = 0;
+ecs_entity_t GlWorld::glecs_meta_callable = 0;
+ecs_entity_t GlWorld::glecs_meta_signal = 0;
+ecs_entity_t GlWorld::glecs_meta_dictionary = 0;
+ecs_entity_t GlWorld::glecs_meta_array = 0;
+ecs_entity_t GlWorld::glecs_meta_packed_int32_array = 0;
+ecs_entity_t GlWorld::glecs_meta_packed_int64_array = 0;
+ecs_entity_t GlWorld::glecs_meta_packed_float32_array = 0;
+ecs_entity_t GlWorld::glecs_meta_packed_float64_array = 0;
+ecs_entity_t GlWorld::glecs_meta_packed_string_array = 0;
+ecs_entity_t GlWorld::glecs_meta_packed_vector2_array = 0;
+ecs_entity_t GlWorld::glecs_meta_packed_vector3_array = 0;
+ecs_entity_t GlWorld::glecs_meta_packed_color_array = 0;
 
 GlWorld::GlWorld() {
 	_raw = ecs_init();
@@ -60,8 +76,8 @@ GlWorld::GlWorld() {
 		ecs_set_scope(_raw, old_scope);
 	}
 
-	// Add glecs/meta/Real type
 	{
+		// Add glecs/meta/Real type
 		ecs_primitive_kind_t kind;
 		if (sizeof(real_t) == sizeof(float)) {
 			kind = ecs_primitive_kind_t::EcsF32;
@@ -285,6 +301,26 @@ GlWorld::GlWorld() {
 		};
 		glecs_meta_color = ecs_struct_init(_raw, &desc);
 	}
+
+	define_gd_component_with_hooks<StringName>("StringName", &glecs_meta_string_name);
+	define_gd_component_with_hooks<NodePath>("NodePath", &glecs_meta_node_path);
+	define_gd_component_with_hooks<RID>("RID", &glecs_meta_rid);
+	define_gd_component_with_hooks<Variant>("Object", &glecs_meta_object);
+	define_gd_component_with_hooks<Callable>("Callable", &glecs_meta_callable);
+	define_gd_component_with_hooks<Signal>("Signal", &glecs_meta_signal);
+	define_gd_component_with_hooks<Variant>("Dictionary", &glecs_meta_dictionary);
+	define_gd_component_with_hooks<Variant>("Array", &glecs_meta_array);
+	define_gd_component_with_hooks<PackedInt32Array>("PackedInt32Array", &glecs_meta_packed_int32_array);
+	define_gd_component_with_hooks<PackedInt64Array>("PackedInt64Array", &glecs_meta_packed_int64_array);
+	define_gd_component_with_hooks<PackedFloat32Array>("PackedFloat32Array", &glecs_meta_packed_float32_array);
+	define_gd_component_with_hooks<PackedFloat64Array>("PackedFloat64Array", &glecs_meta_packed_float64_array);
+	define_gd_component_with_hooks<PackedStringArray>("PackedStringArray", &glecs_meta_packed_string_array);
+	define_gd_component_with_hooks<PackedVector2Array>("PackedVector2Array", &glecs_meta_packed_vector2_array);
+	define_gd_component_with_hooks<PackedVector3Array>("PackedVector3Array", &glecs_meta_packed_vector3_array);
+	define_gd_component_with_hooks<PackedColorArray>("PackedColorArray", &glecs_meta_packed_color_array);
+
+	#undef DEFINE_GD_COMPONENT
+	#undef DEFINE_GD_COMPONENT_WITH_HOOKS
 }
 
 GlWorld::~GlWorld() {

--- a/addons/glecs/cpp/src/world.cpp
+++ b/addons/glecs/cpp/src/world.cpp
@@ -11,9 +11,280 @@
 
 using namespace godot;
 
+ecs_entity_t GlWorld::glecs = 0;
+ecs_entity_t GlWorld::glecs_meta = 0;
+ecs_entity_t GlWorld::glecs_meta_real = 0;
+ecs_entity_t GlWorld::glecs_meta_vector2 = 0;
+ecs_entity_t GlWorld::glecs_meta_vector2i = 0;
+ecs_entity_t GlWorld::glecs_meta_rect2 = 0;
+ecs_entity_t GlWorld::glecs_meta_rect2i = 0;
+ecs_entity_t GlWorld::glecs_meta_vector3 = 0;
+ecs_entity_t GlWorld::glecs_meta_vector3i = 0;
+ecs_entity_t GlWorld::glecs_meta_transform2d = 0;
+ecs_entity_t GlWorld::glecs_meta_vector4 = 0;
+ecs_entity_t GlWorld::glecs_meta_vector4i = 0;
+ecs_entity_t GlWorld::glecs_meta_plane = 0;
+ecs_entity_t GlWorld::glecs_meta_quaternion = 0;
+ecs_entity_t GlWorld::glecs_meta_aabb = 0;
+ecs_entity_t GlWorld::glecs_meta_basis = 0;
+ecs_entity_t GlWorld::glecs_meta_transform3d = 0;
+ecs_entity_t GlWorld::glecs_meta_projection = 0;
+ecs_entity_t GlWorld::glecs_meta_color = 0;
+
 GlWorld::GlWorld() {
 	_raw = ecs_init();
 	ECS_IMPORT(raw(), FlecsStats);
+
+	// Add glecs module
+	ecs_component_desc_t empty_desc = {0};
+	glecs = ecs_module_init(
+		_raw,
+		"glecs",
+		&empty_desc
+	);
+
+	// Add glecs/meta module
+	{
+		ecs_entity_t old_scope = ecs_get_scope(_raw);
+		ecs_set_scope(_raw, glecs);
+
+		ecs_component_desc_t comp_desc = {
+			.entity = ecs_new_from_path(_raw, glecs, "meta"),
+		};
+		glecs_meta = ecs_module_init(
+			_raw,
+			"meta",
+			&comp_desc
+		);
+
+		ecs_set_scope(_raw, old_scope);
+	}
+
+	// Add glecs/meta/Real type
+	{
+		ecs_primitive_kind_t kind;
+		if (sizeof(real_t) == sizeof(float)) {
+			kind = ecs_primitive_kind_t::EcsF32;
+		} else if (sizeof(real_t) == sizeof(double)) {
+			kind = ecs_primitive_kind_t::EcsF64;
+		} else {
+			throw "Godot's real_t type is somehow not a float or double";
+		}
+		ecs_primitive_desc_t primi_desc = {
+			.entity = ecs_new_from_path(_raw, glecs_meta, "Real"),
+			.kind = kind
+		};
+		glecs_meta_real = ecs_primitive_init(_raw, &primi_desc);
+	}
+
+	{
+		// Add glecs/meta/Vector2 type
+		ecs_struct_desc_t desc = {
+			.entity = ecs_new_from_path(_raw, glecs_meta, "Vector2"),
+			.members = {
+				{.name = "x", .type = glecs_meta_real},
+				{.name = "y", .type = glecs_meta_real}
+			}
+		};
+		glecs_meta_vector2 = ecs_struct_init(_raw, &desc);
+	}
+
+	{
+		// Add glecs/meta/Vector2i type
+		ecs_struct_desc_t desc = {
+			.entity = ecs_new_from_path(_raw, glecs_meta, "Vector2i"),
+			.members = {
+				{.name = "x", .type = ecs_id(ecs_i32_t)},
+				{.name = "y", .type = ecs_id(ecs_i32_t)}
+			}
+		};
+		glecs_meta_vector2i = ecs_struct_init(_raw, &desc);
+	}
+
+	{
+		// Add glecs/meta/Rect type
+		ecs_struct_desc_t desc = {
+			.entity = ecs_new_from_path(_raw, glecs_meta, "Rect2"),
+			.members = {
+				{.name = "position", .type = glecs_meta_vector2},
+				{.name = "size", .type = glecs_meta_vector2}
+			}
+		};
+		glecs_meta_rect2 = ecs_struct_init(_raw, &desc);
+	}
+
+	{
+		// Add glecs/meta/Rect2i type
+		ecs_struct_desc_t desc = {
+			.entity = ecs_new_from_path(_raw, glecs_meta, "Rect2i"),
+			.members = {
+				{.name = "position", .type = glecs_meta_vector2i},
+				{.name = "size", .type = glecs_meta_vector2i}
+			}
+		};
+		glecs_meta_rect2i = ecs_struct_init(_raw, &desc);
+	}
+
+	{
+		// Add glecs/meta/Vector3 type
+		ecs_struct_desc_t desc = {
+			.entity = ecs_new_from_path(_raw, glecs_meta, "Vector3"),
+			.members = {
+				{.name = "x", .type = glecs_meta_real},
+				{.name = "y", .type = glecs_meta_real},
+				{.name = "z", .type = glecs_meta_real}
+			}
+		};
+		glecs_meta_vector3 = ecs_struct_init(_raw, &desc);
+	}
+
+	{
+		// Add glecs/meta/Vector3i type
+		ecs_struct_desc_t desc = {
+			.entity = ecs_new_from_path(_raw, glecs_meta, "Vector3i"),
+			.members = {
+				{.name = "x", .type = ecs_id(ecs_i32_t)},
+				{.name = "y", .type = ecs_id(ecs_i32_t)},
+				{.name = "z", .type = ecs_id(ecs_i32_t)}
+			}
+		};
+		glecs_meta_vector3i = ecs_struct_init(_raw, &desc);
+	}
+
+	{
+		// Add glecs/meta/Transform2D type
+		ecs_struct_desc_t desc = {
+			.entity = ecs_new_from_path(_raw, glecs_meta, "Transform2D"),
+			.members = {
+				{.name = "x", .type = glecs_meta_vector2},
+				{.name = "y", .type = glecs_meta_vector2},
+				{.name = "origin", .type = glecs_meta_vector2}
+			}
+		};
+		glecs_meta_transform2d = ecs_struct_init(_raw, &desc);
+	}
+
+	{
+		// Add glecs/meta/Vector4 type
+		ecs_struct_desc_t desc = {
+			.entity = ecs_new_from_path(_raw, glecs_meta, "Vector4"),
+			.members = {
+				{.name = "x", .type = glecs_meta_real},
+				{.name = "y", .type = glecs_meta_real},
+				{.name = "z", .type = glecs_meta_real},
+				{.name = "w", .type = glecs_meta_real}
+			}
+		};
+		glecs_meta_vector4 = ecs_struct_init(_raw, &desc);
+	}
+
+	{
+		// Add glecs/meta/Vector4i type
+		ecs_struct_desc_t desc = {
+			.entity = ecs_new_from_path(_raw, glecs_meta, "Vector4i"),
+			.members = {
+				{.name = "x", .type = ecs_id(ecs_i32_t)},
+				{.name = "y", .type = ecs_id(ecs_i32_t)},
+				{.name = "z", .type = ecs_id(ecs_i32_t)},
+				{.name = "w", .type = ecs_id(ecs_i32_t)}
+			}
+		};
+		glecs_meta_vector4i = ecs_struct_init(_raw, &desc);
+	}
+
+	{
+		// Add glecs/meta/Plane type
+		ecs_struct_desc_t desc = {
+			.entity = ecs_new_from_path(_raw, glecs_meta, "Plane"),
+			.members = {
+				{.name = "x", .type = glecs_meta_real},
+				{.name = "y", .type = glecs_meta_real},
+				{.name = "z", .type = glecs_meta_real},
+				{.name = "d", .type = glecs_meta_real},
+				{.name = "normal", .type = glecs_meta_vector3}
+			}
+		};
+		glecs_meta_plane = ecs_struct_init(_raw, &desc);
+	}
+
+	{
+		// Add glecs/meta/Quaternion type
+		ecs_struct_desc_t desc = {
+			.entity = ecs_new_from_path(_raw, glecs_meta, "Quaternion"),
+			.members = {
+				{.name = "x", .type = glecs_meta_real},
+				{.name = "y", .type = glecs_meta_real},
+				{.name = "z", .type = glecs_meta_real},
+				{.name = "w", .type = glecs_meta_real}
+			}
+		};
+		glecs_meta_quaternion = ecs_struct_init(_raw, &desc);
+	}
+
+	{
+		// Add glecs/meta/AABB type
+		ecs_struct_desc_t desc = {
+			.entity = ecs_new_from_path(_raw, glecs_meta, "AABB"),
+			.members = {
+				{.name = "position", .type = glecs_meta_vector3},
+				{.name = "size", .type = glecs_meta_vector3}
+			}
+		};
+		glecs_meta_aabb = ecs_struct_init(_raw, &desc);
+	}
+
+	{
+		// Add glecs/meta/Basis type
+		ecs_struct_desc_t desc = {
+			.entity = ecs_new_from_path(_raw, glecs_meta, "Basis"),
+			.members = {
+				{.name = "x", .type = glecs_meta_vector3},
+				{.name = "y", .type = glecs_meta_vector3},
+				{.name = "z", .type = glecs_meta_vector3}
+			}
+		};
+		glecs_meta_basis = ecs_struct_init(_raw, &desc);
+	}
+
+	{
+		// Add glecs/meta/Transform3D type
+		ecs_struct_desc_t desc = {
+			.entity = ecs_new_from_path(_raw, glecs_meta, "Transform3D"),
+			.members = {
+				{.name = "basis", .type = glecs_meta_basis},
+				{.name = "origin", .type = glecs_meta_vector3}
+			}
+		};
+		glecs_meta_transform3d = ecs_struct_init(_raw, &desc);
+	}
+
+	{
+		// Add glecs/meta/Projection type
+		ecs_struct_desc_t desc = {
+			.entity = ecs_new_from_path(_raw, glecs_meta, "Projection"),
+			.members = {
+				{.name = "x", .type = glecs_meta_vector4},
+				{.name = "y", .type = glecs_meta_vector4},
+				{.name = "z", .type = glecs_meta_vector4},
+				{.name = "w", .type = glecs_meta_vector4}
+			}
+		};
+		glecs_meta_projection = ecs_struct_init(_raw, &desc);
+	}
+
+	{
+		// Add glecs/meta/Color type
+		ecs_struct_desc_t desc = {
+			.entity = ecs_new_from_path(_raw, glecs_meta, "Color"),
+			.members = {
+				{.name = "r", .type = ecs_id(ecs_f32_t)},
+				{.name = "g", .type = ecs_id(ecs_f32_t)},
+				{.name = "b", .type = ecs_id(ecs_f32_t)},
+				{.name = "a", .type = ecs_id(ecs_f32_t)}
+			}
+		};
+		glecs_meta_color = ecs_struct_init(_raw, &desc);
+	}
 }
 
 GlWorld::~GlWorld() {

--- a/addons/glecs/cpp/src/world.h
+++ b/addons/glecs/cpp/src/world.h
@@ -28,6 +28,8 @@ namespace godot {
 		ecs_entity_t coerce_id(Variant);
 		void progress(double delta);
 		void start_rest_api();
+		static ecs_entity_t variant_type_to_id(Variant::Type);
+		static Variant::Type id_to_variant_type(ecs_entity_t);
 
 		// **************************************
 		// *** Unexposed ***
@@ -37,6 +39,11 @@ namespace godot {
 		static ecs_entity_t glecs;
 		static ecs_entity_t glecs_meta;
 		static ecs_entity_t glecs_meta_real;
+		static ecs_entity_t glecs_meta_nil;
+		static ecs_entity_t glecs_meta_bool;
+		static ecs_entity_t glecs_meta_int;
+		static ecs_entity_t glecs_meta_float;
+		static ecs_entity_t glecs_meta_string;
 		static ecs_entity_t glecs_meta_vector2;
 		static ecs_entity_t glecs_meta_vector2i;
 		static ecs_entity_t glecs_meta_rect2;
@@ -61,6 +68,7 @@ namespace godot {
 		static ecs_entity_t glecs_meta_signal;
 		static ecs_entity_t glecs_meta_dictionary;
 		static ecs_entity_t glecs_meta_array;
+		static ecs_entity_t glecs_meta_packed_byte_array;
 		static ecs_entity_t glecs_meta_packed_int32_array;
 		static ecs_entity_t glecs_meta_packed_int64_array;
 		static ecs_entity_t glecs_meta_packed_float32_array;
@@ -143,12 +151,12 @@ namespace godot {
 			ecs_entity_t* static_id
 		) {
 			ecs_component_desc_t desc = {
+				.entity = *static_id,
 				.type = {
 					.size = sizeof(T),
 					.alignment = 8
 				}
-			};
-			*static_id = ecs_component_init(_raw, &desc);
+			}; ecs_component_init(_raw, &desc);
 			ecs_type_hooks_t hooks = {
 				.ctor = GlWorld::gd_type_ctor<T>,
 				.dtor = GlWorld::gd_type_dtor<T>,
@@ -160,11 +168,12 @@ namespace godot {
 				*static_id,
 				glecs_meta,
 				name,
-				"",
+				"/",
 				"/root/"
 			);
 		}
 
+		void define_gd_literal(const char*, ecs_primitive_kind_t, ecs_entity_t* id_storage);
 	};
 }
 

--- a/addons/glecs/cpp/src/world.h
+++ b/addons/glecs/cpp/src/world.h
@@ -4,8 +4,12 @@
 
 #include <flecs.h>
 #include <godot_cpp/classes/object.hpp>
+#include <godot_cpp/classes/ref_counted.hpp>
 
 namespace godot {
+
+	// Predefine instead of include to avoid cyclic dependencies
+	class GlComponentBuilder;
 
 	class GlWorld : public Object {
 		GDCLASS(GlWorld, Object)
@@ -14,12 +18,21 @@ namespace godot {
 		GlWorld();
 		~GlWorld();
 
-		static GlWorld* singleton();
+		// **************************************
+		// *** Exposed ***
+		// **************************************
+
+		Ref<GlComponentBuilder> component_builder();
 
 		ecs_entity_t coerce_id(Variant);
 		void progress(double delta);
 		void start_rest_api();
 
+		// **************************************
+		// *** Unexposed ***
+		// **************************************
+
+		static GlWorld* singleton();
 		ecs_world_t* raw();
 
 	protected:

--- a/addons/glecs/cpp/src/world.h
+++ b/addons/glecs/cpp/src/world.h
@@ -78,6 +78,10 @@ namespace godot {
 		static ecs_entity_t glecs_meta_packed_vector3_array;
 		static ecs_entity_t glecs_meta_packed_color_array;
 
+		void copy_component_ptr(const void*, void*, ecs_entity_t);
+		void copy_gd_type_ptr(const void*, void*, ecs_entity_t);
+		void deinit_component_ptr(void*, ecs_entity_t);
+		void deinit_gd_type_ptr(void*, ecs_entity_t);
 		void init_component_ptr(void*, ecs_entity_t, Variant);
 		void init_gd_type_ptr(void*, ecs_entity_t);
 
@@ -99,7 +103,6 @@ namespace godot {
 			T* list = (T*)ptr;
 			for (int i=0; i != count; i++) {
 				T value = T();
-				UtilityFunctions::print("ANY CTOR ", reinterpret_cast<uintptr_t>(&list[i]), ", ", value);
 				list[i] = value;
 			}
 		}
@@ -126,7 +129,6 @@ namespace godot {
 			T* dst_list = (T*)dst_ptr;
 			const T* src_list = (const T*)src_ptr;
 			for (int i=0; i != count; i++) {
-				UtilityFunctions::print("ANY COPY ", reinterpret_cast<uintptr_t>(&src_list[i]));
 				dst_list[i] = T(src_list[i]);
 			}
 		}

--- a/addons/glecs/cpp/src/world.h
+++ b/addons/glecs/cpp/src/world.h
@@ -52,6 +52,22 @@ namespace godot {
 		static ecs_entity_t glecs_meta_transform3d;
 		static ecs_entity_t glecs_meta_projection;
 		static ecs_entity_t glecs_meta_color;
+		static ecs_entity_t glecs_meta_string_name;
+		static ecs_entity_t glecs_meta_node_path;
+		static ecs_entity_t glecs_meta_rid;
+		static ecs_entity_t glecs_meta_object;
+		static ecs_entity_t glecs_meta_callable;
+		static ecs_entity_t glecs_meta_signal;
+		static ecs_entity_t glecs_meta_dictionary;
+		static ecs_entity_t glecs_meta_array;
+		static ecs_entity_t glecs_meta_packed_int32_array;
+		static ecs_entity_t glecs_meta_packed_int64_array;
+		static ecs_entity_t glecs_meta_packed_float32_array;
+		static ecs_entity_t glecs_meta_packed_float64_array;
+		static ecs_entity_t glecs_meta_packed_string_array;
+		static ecs_entity_t glecs_meta_packed_vector2_array;
+		static ecs_entity_t glecs_meta_packed_vector3_array;
+		static ecs_entity_t glecs_meta_packed_color_array;
 
 		static GlWorld* singleton();
 		ecs_world_t* raw();
@@ -61,6 +77,87 @@ namespace godot {
 
 	private:
 		ecs_world_t* _raw;
+
+		template<typename T>
+		static void gd_type_ctor(
+			void* ptr,
+			int32_t count,
+			const ecs_type_info_t* type_info
+		) {
+			T* list = (T*)ptr;
+			for (int i=0; i != count; i++) {
+				list[i] = T();
+			}
+		}
+
+		template<typename T>
+		static void gd_type_dtor(
+			void* ptr,
+			int32_t count,
+			const ecs_type_info_t* type_info
+		) {
+			T* list = (T*)ptr;
+			for (int i=0; i != count; i++) {
+				list[i].~T();
+			}
+		}
+
+		template<typename T>
+		static void gd_type_copy(
+			void* dst_ptr,
+			const void* src_ptr,
+			int32_t count,
+			const ecs_type_info_t* type_info
+		) {
+			T* dst_list = (T*)dst_ptr;
+			const T* src_list = (const T*)src_ptr;
+			for (int i=0; i != count; i++) {
+				dst_list[i] = T(src_list[i]);
+			}
+		}
+
+		template<typename T>
+		static void gd_type_move(
+			void* dst_ptr,
+			void* src_ptr,
+			int32_t count,
+			const ecs_type_info_t* type_info
+		) {
+			T* dst_list = (T*)dst_ptr;
+			T* src_list = (T*)src_ptr;
+			for (int i=0; i != count; i++) {
+				dst_list[i] = T(src_list[i]);
+			}
+		}
+
+		template<typename T>
+		void define_gd_component(
+			const char* name,
+			ecs_entity_t* static_id
+		) {
+			ecs_component_desc_t desc = {
+				.entity = ecs_new_from_path(_raw, glecs_meta, name),
+				.type = {
+					.size = sizeof(T),
+					.alignment = 8
+				}
+			};
+			*static_id = ecs_component_init(_raw, &desc);
+		}
+
+		template<typename T>
+		void define_gd_component_with_hooks(
+			const char* name,
+			ecs_entity_t* static_id
+		) {
+			define_gd_component<T>(name, static_id);
+			ecs_type_hooks_t hooks = {
+				.ctor = GlWorld::gd_type_ctor<T>,
+				.dtor = GlWorld::gd_type_dtor<T>,
+				.copy = GlWorld::gd_type_copy<T>,
+				.move = GlWorld::gd_type_move<T>
+			}; ecs_set_hooks_id(_raw, *static_id, &hooks);
+		}
 
 	};
 }

--- a/addons/glecs/cpp/src/world.h
+++ b/addons/glecs/cpp/src/world.h
@@ -32,6 +32,27 @@ namespace godot {
 		// *** Unexposed ***
 		// **************************************
 
+		// *** Glecs entities ***
+		static ecs_entity_t glecs;
+		static ecs_entity_t glecs_meta;
+		static ecs_entity_t glecs_meta_real;
+		static ecs_entity_t glecs_meta_vector2;
+		static ecs_entity_t glecs_meta_vector2i;
+		static ecs_entity_t glecs_meta_rect2;
+		static ecs_entity_t glecs_meta_rect2i;
+		static ecs_entity_t glecs_meta_vector3;
+		static ecs_entity_t glecs_meta_vector3i;
+		static ecs_entity_t glecs_meta_transform2d;
+		static ecs_entity_t glecs_meta_vector4;
+		static ecs_entity_t glecs_meta_vector4i;
+		static ecs_entity_t glecs_meta_plane;
+		static ecs_entity_t glecs_meta_quaternion;
+		static ecs_entity_t glecs_meta_aabb;
+		static ecs_entity_t glecs_meta_basis;
+		static ecs_entity_t glecs_meta_transform3d;
+		static ecs_entity_t glecs_meta_projection;
+		static ecs_entity_t glecs_meta_color;
+
 		static GlWorld* singleton();
 		ecs_world_t* raw();
 


### PR DESCRIPTION
This PR adds the class and functionality for the GlComponentBuilder. It also implements the various hooks required to safely handle Godot defined components.